### PR TITLE
AM/interview/ruby-take-home

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,7 @@ gem 'sinatra-contrib'
 gem 'puma'
 gem 'rackup'
 gem 'irb'
+
+group :test do
+  gem 'rack-test'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,8 @@ GEM
     rack (2.2.8)
     rack-protection (3.1.0)
       rack (~> 2.2, >= 2.2.4)
+    rack-test (2.1.0)
+      rack (>= 1.3)
     rackup (1.0.0)
       rack (< 3)
       webrick
@@ -53,6 +55,7 @@ DEPENDENCIES
   irb
   pg (~> 1.5.3)
   puma
+  rack-test
   rackup
   redis
   sinatra (~> 3.1.0)

--- a/boot.rb
+++ b/boot.rb
@@ -4,7 +4,9 @@ BASE_PATH = File.dirname(File.absolute_path(__FILE__))
 $: << BASE_PATH + "/lib"
 
 require 'vandelay'
+require 'vandelay/util/cache'
 require 'vandelay/util/db'
 require 'vandelay/models'
+require 'vandelay/integrations'
 
 Vandelay::Util::DB.verify_connection! unless Vandelay::Util::DB.connection_verified?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
     container_name: mock_api_two
     image: clue/json-server
     volumes:
-      - ./externals/mock_api_one:/data
+      - ./externals/mock_api_two:/data
     ports:
       - "3061:80"
 

--- a/lib/vandelay/integrations.rb
+++ b/lib/vandelay/integrations.rb
@@ -1,0 +1,7 @@
+Dir[File.dirname(__FILE__) + '/integrations/**/*.rb'].each {|rb| require_relative rb }
+
+module Vandelay
+  module Integrations
+    # nothing to add here right now
+  end
+end

--- a/lib/vandelay/integrations/base.rb
+++ b/lib/vandelay/integrations/base.rb
@@ -1,0 +1,49 @@
+require 'uri'
+require 'net/http'
+
+module Vandelay
+  module Integrations
+    class Base
+      def patient_url
+        raise NoMethodError
+      end
+
+      def port
+        raise NoMethodError
+      end
+
+      def hostname
+        raise NoMethodError
+      end
+
+      def bearer_token
+        raise NoMethodError
+      end
+
+      def get_token
+        raise NoMethodError
+      end
+
+      def get_patient_record(id)
+        response_body = fetch_patient_url(id)
+        get_required_fields(JSON.parse(response_body))
+      end
+
+      def fetch_patient_url(id)
+        # Normally, could also use the uri and then uri.hostname and uri.port
+        http = Net::HTTP.new(hostname, port)
+        req = Net::HTTP::Get.new(patient_url + id.to_s)
+        # Add the Bearer Token (fetched once) in the header of all requests.
+        req["Authorization"] = "Bearer #{self.class.bearer_token}"
+        req["Content-Type"] = "application/json"
+        response = http.request(req)
+        return unless response.is_a?(Net::HTTPSuccess)
+        response.body
+      end
+
+      def get_required_fields(params)
+        raise NoMethodError
+      end
+    end
+  end
+end

--- a/lib/vandelay/integrations/vendor_one/v1/api_client.rb
+++ b/lib/vandelay/integrations/vendor_one/v1/api_client.rb
@@ -1,0 +1,57 @@
+module Vandelay
+  module Integrations
+    module VendorOne
+      module V1
+        class ApiClient < Vandelay::Integrations::Base
+          class << self
+            attr_accessor :bearer_token
+          end
+        
+          @bearer_token = nil
+        
+          def initialize
+            self.class.bearer_token ||= get_token
+          end
+          
+          # These can be stored in ENV or config
+          API_V1_HOST = ENV["VENDOR_ONE_API_V1_HOST"] || "http:://localhost:3060"
+          GET_RECORD_PATH = "/patients/"
+          AUTH_PATH = "/auth/1"
+          PORT = 3060          
+
+          private_constant :API_V1_HOST, :GET_RECORD_PATH, :AUTH_PATH, :PORT
+
+          def patient_url
+            #"#{API_V1_HOST}#{GET_RECORD_PATH}"
+            GET_RECORD_PATH
+          end
+
+          def hostname
+            "host.docker.internal"
+          end
+
+          def port
+            PORT
+          end
+
+          def get_token
+            http = Net::HTTP.new(hostname, port)
+            req = Net::HTTP::Get.new(AUTH_PATH)      
+            response = http.request(req)
+            return unless response.is_a?(Net::HTTPSuccess)
+            JSON.parse(response.body)["token"]
+          end
+
+          def get_required_fields(params)
+            {
+              "patient_id": params["id"],
+              "province": params["province"],
+              "allergies": params["allergies"],
+              "num_medical_visits": params["recent_medical_visits"]
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vandelay/integrations/vendor_two/v1/api_client.rb
+++ b/lib/vandelay/integrations/vendor_two/v1/api_client.rb
@@ -1,0 +1,60 @@
+module Vandelay
+  module Integrations
+    module VendorTwo
+      module V1
+        class ApiClient < Vandelay::Integrations::Base
+          class << self
+            attr_accessor :bearer_token
+          end
+        
+          @bearer_token = nil
+        
+          def initialize
+            self.class.bearer_token ||= get_token
+          end
+
+          # These can be stored in ENV or config 
+          # Normally, just the host url would be enough, and can use uri.hostname and uri.port
+          API_V1_HOST = ENV["VENDOR_TWO_API_V1_HOST"] || "http:://localhost:3061"
+          GET_RECORD_PATH = "/records/"
+          AUTH_PATH = "/auth_tokens/1"
+          PORT = 3061
+
+          private_constant :API_V1_HOST, :GET_RECORD_PATH, :AUTH_PATH, :PORT
+
+          def port
+            PORT
+          end
+
+          def hostname
+            # instead of localhost so that it will work with docker.
+            "host.docker.internal"
+          end
+
+          def patient_url
+            #"#{API_V1_HOST}#{GET_RECORD_PATH}"
+            GET_RECORD_PATH
+          end
+
+
+          def get_token
+            http = Net::HTTP.new(hostname, port)
+            req = Net::HTTP::Get.new(AUTH_PATH)   
+            response = http.request(req)
+            return unless response.is_a?(Net::HTTPSuccess)
+            JSON.parse(response.body)["auth_token"]
+          end
+
+          def get_required_fields(params)
+            {
+              "patient_id": params["id"],
+              "province": params["province_code"],
+              "allergies": params["allergies_list"],
+              "num_medical_visits": params["medical_visits_recently"]
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vandelay/models/base.rb
+++ b/lib/vandelay/models/base.rb
@@ -22,7 +22,7 @@ module Vandelay
         end
       end
 
-      def to_json(_opts)
+      def to_json(_opts={})
         JSON.dump(self.to_h)
       end
 

--- a/lib/vandelay/rest/patients_patient.rb
+++ b/lib/vandelay/rest/patients_patient.rb
@@ -4,8 +4,22 @@ require 'vandelay/services/patient_records'
 module Vandelay
   module REST
     module PatientsPatient
+      def self.patients_srvc
+        @patients_srvc ||= Vandelay::Services::Patients.new
+      end
+
       def self.registered(app)
-        # add endpoint code here
+        app.get '/patients/:id' do
+          if params['id'].to_i.to_s != params['id']
+            return json({ status: 422, message: "Invalid patient id", system_time: Vandelay.system_time_now.iso8601 })
+          end
+          result = Vandelay::REST::PatientsPatient.patients_srvc.retrieve_one(params['id'])
+          if result.nil?
+            return json({ status: 404, message: "Patient not found", system_time: Vandelay.system_time_now.iso8601 })
+          else
+            json(result)
+          end
+        end
       end
     end
   end

--- a/lib/vandelay/rest/patients_patient_record.rb
+++ b/lib/vandelay/rest/patients_patient_record.rb
@@ -1,0 +1,36 @@
+require 'vandelay/services/patients'
+require 'vandelay/services/patient_records'
+
+module Vandelay
+  module REST
+    module PatientsPatientRecord
+      def self.patient_records_srvc
+        @patient_records_srvc ||= Vandelay::Services::PatientRecords.new
+      end
+
+      def self.patients_srvc
+        @patients_srvc ||= Vandelay::Services::Patients.new
+      end
+
+      def self.registered(app)
+        app.get '/patients/:patient_id/record' do
+          if params['patient_id'].to_i.to_s != params['patient_id']
+            halt json({ status: 422, message: "Invalid Patient Id", system_time: Vandelay.system_time_now.iso8601 })
+          end
+
+          patient = Vandelay::REST::PatientsPatientRecord.patients_srvc.retrieve_one(params['patient_id'])         
+          if patient.nil?
+            halt json({ status: 404, message: "Patient not found", system_time: Vandelay.system_time_now.iso8601 })
+          end
+
+          result = Vandelay::REST::PatientsPatientRecord.patient_records_srvc.retrieve_record_for_patient(patient)
+          if result.nil?
+            json({ status: 404, message: "Unable to find patient record", system_time: Vandelay.system_time_now.iso8601 })
+          else
+            json(result)
+          end
+        end     
+      end
+    end
+  end
+end

--- a/lib/vandelay/services/patient_records.rb
+++ b/lib/vandelay/services/patient_records.rb
@@ -1,8 +1,34 @@
 module Vandelay
   module Services
     class PatientRecords
+      INTEGRATIONS = {
+        "one" => Vandelay::Integrations::VendorOne::V1::ApiClient.new,
+        "two" => Vandelay::Integrations::VendorTwo::V1::ApiClient.new
+      }
+
       def retrieve_record_for_patient(patient)
-        # add logic here
+        patient_record = nil
+        if patient.records_vendor.nil? || patient.vendor_id.nil?
+          return { status: 422, message: "Missing vendor details. Patient Id: #{patient.id}"}
+        end
+        key = cache_key(patient)
+        if Vandelay::Util::Cache.key_present?(key)
+          # Get cached data if available
+          patient_record = Vandelay::Util::Cache.get_cached_data(key)
+        else
+          if INTEGRATIONS[patient.records_vendor]
+            # Get record if registered vendor available.
+            patient_record = INTEGRATIONS[patient.records_vendor].get_patient_record(patient.vendor_id)
+            Vandelay::Util::Cache.cache_data(key, patient_record) if patient_record
+          else
+            return { status: 422, message: "Invalid Vendor. Patient Id: #{patient.id}, Vendor: #{patient.records_vendor}"}
+          end
+        end
+        return patient_record
+      end
+
+      def cache_key(patient)
+        "Patient_#{patient.id}_#{patient.records_vendor}_#{patient.vendor_id}"
       end
     end
   end

--- a/lib/vandelay/util/cache.rb
+++ b/lib/vandelay/util/cache.rb
@@ -1,9 +1,25 @@
 require 'redis'
-
 module Vandelay
   module Util
     class Cache
+      EXPIRES_IN_SECONDS = 10 * 60
+
       # your code here
+      def self.redis
+        @redis ||= Redis.new(host: "host.docker.internal", port: 6387)
+      end
+
+      def self.cache_data(key, data)
+        Vandelay::Util::Cache.redis.set(key, Marshal.dump(data), ex: EXPIRES_IN_SECONDS)
+      end
+
+      def self.get_cached_data(key)      
+        Marshal.load(Vandelay::Util::Cache.redis.get(key)) if Vandelay::Util::Cache.redis.get(key)
+      end
+
+      def self.key_present?(key)
+        Vandelay::Util::Cache.redis.get(key) != nil
+      end
     end
   end
 end

--- a/server.rb
+++ b/server.rb
@@ -13,6 +13,7 @@ class RESTServer < Sinatra::Base
     set :root, File.dirname(__FILE__) + "/lib/vandelay/rest"
     set :server, %w[puma]
     set :json_encoder, :to_json
+    set :show_exceptions, false
   end
 
   register Vandelay::REST

--- a/tests/lib/vandelay/rest/patients_patient.rb
+++ b/tests/lib/vandelay/rest/patients_patient.rb
@@ -1,0 +1,29 @@
+require_relative '../../../test_helper'
+
+class PatientsPatientTest < RestServerTest
+  def test_it_returns_patient
+    get '/patients/2'
+    assert last_response.ok?
+    assert_equal ({
+      "id":"2",
+      "full_name":"Cosmo Kramer",
+      "date_of_birth":"1987-03-18",
+      "records_vendor":"one",
+      "vendor_id":"743"
+    }.to_json), last_response.body
+  end
+
+  def test_error_for_missing_id
+    get '/patients/5'
+    assert last_response.ok?
+    assert_equal 404, JSON.parse(last_response.body)["status"]
+    assert_equal "Patient not found", JSON.parse(last_response.body)["message"]
+  end
+
+  def test_error_for_invalid_id
+    get '/patients/okok'
+    assert last_response.ok?
+    assert_equal 422, JSON.parse(last_response.body)["status"]
+    assert_equal "Invalid patient id", JSON.parse(last_response.body)["message"]
+  end
+end

--- a/tests/lib/vandelay/rest/patients_patient_record.rb
+++ b/tests/lib/vandelay/rest/patients_patient_record.rb
@@ -1,0 +1,28 @@
+require_relative '../../../test_helper'
+
+class PatientsPatientRecordTest < RestServerTest
+  def test_it_returns_patient_record
+    get '/patients/2/record'
+    assert last_response.ok?
+    assert_equal ({
+      "patient_id": "743",
+      "province": "QC",
+      "allergies": ["work", "conformity", "paying taxes"],
+      "num_medical_visits": 1
+    }.to_json), last_response.body
+  end
+
+  def test_missing_patient
+    get '/patients/5/record'
+    assert last_response.ok?
+    assert_equal 404, JSON.parse(last_response.body)["status"]
+    assert_equal "Patient not found", JSON.parse(last_response.body)["message"]
+  end
+
+  def test_patient_with_missing_vendor
+    get '/patients/1/record'
+    assert last_response.ok?
+    assert_equal 422, JSON.parse(last_response.body)["status"]
+    assert_equal "Missing vendor details. Patient Id: 1", JSON.parse(last_response.body)["message"]
+  end
+end

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -1,0 +1,12 @@
+ENV['APP_ENV'] = 'test'
+require 'minitest/autorun'
+require 'rack/test'
+require_relative '../server'
+
+class RestServerTest < Minitest::Test
+  include Rack::Test::Methods
+ 
+  def app
+    RESTServer
+  end
+end


### PR DESCRIPTION
1. In the /lib/vandelay/rest/patients_patient.rb file, added a new endpoint that retrieves a single patient from the db, and responds with it. Errors are currently just returned as json with a status code, in keeping with the existing code convention. We could change that to raise errors instead and handle errors to display user messages or pass on the errors as different status errors to the user, depending on the API requirement.

2. Added the service to get a patient record with caching in /lib/vandelay/services/patient_records.rb .

- This service checks the patient table's record vendor to decide which vendor to use.

- Each vendor integration ( in integrations/vendor.. ) get the auth token just once. Then that auth token is used in all the requests that are sent to that vendor. This is done by using a class instance variable which is initialized just once.

- The util/cache also uses redis to cache the patient record response for 10 minutes. The service checks if the cached version is available and returns that if yes, otherwise makes a http request to the appropriate vendor to get the patient records.

3. The tests are written in tests/lib/vandelay/rest for patients_patient and patients_patient_record which are the 2 new rest endpoints implemented. The tests are not complete. Need to add tests for caching and authentication. Also would use mocks / webmock or vcr etc so that external API requests are not done each time for every test.
Currently the tests can be run as ```ruby tests/lib/vandelay/rest/patients_patient.rb``` and ```ruby tests/lib/vandelay/rest/patients_patient_record.rb``` . We could create a rake task that runs all the files in the tests directory so that just running that rake task would run all the tests at once.

4. The method of connecting to the mock_api_one, mock_api_two and redis servers is currently using a port and hostname, to make it work in docker. Just using localhost and uri was not working and caused ```Errno::EADDRNOTAVAIL - Failed to open TCP connection to localhost:3060 (Cannot assign requested address - connect(2) for "localhost" port 3060)``` . Also we would normally use the config file or ENV vars to set the base url and the patient and auth urls etc for each vendor, instead of in the api_client.rb. I also updated the docker_compose to get the correct data for the vendor two.