### PR TITLE
hv/interview/ruby take home

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,9 @@ gem 'sinatra-contrib'
 gem 'puma'
 gem 'rackup'
 gem 'irb'
+
+group :test do
+  gem "rspec"
+  gem "rack-test"
+  gem 'simplecov', require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,8 @@ GEM
   remote: https://rubygems.org/
   specs:
     connection_pool (2.4.1)
+    diff-lcs (1.5.1)
+    docile (1.4.0)
     io-console (0.6.0)
     irb (1.8.1)
       rdoc
@@ -18,6 +20,8 @@ GEM
     rack (2.2.8)
     rack-protection (3.1.0)
       rack (~> 2.2, >= 2.2.4)
+    rack-test (2.1.0)
+      rack (>= 1.3)
     rackup (1.0.0)
       rack (< 3)
       webrick
@@ -29,7 +33,26 @@ GEM
       connection_pool
     reline (0.3.8)
       io-console (~> 0.5)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
     ruby2_keywords (0.0.5)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sinatra (3.1.0)
       mustermann (~> 3.0)
       rack (~> 2.2, >= 2.2.4)
@@ -53,8 +76,11 @@ DEPENDENCIES
   irb
   pg (~> 1.5.3)
   puma
+  rack-test
   rackup
   redis
+  rspec
+  simplecov
   sinatra (~> 3.1.0)
   sinatra-contrib
 

--- a/config.dev.yml
+++ b/config.dev.yml
@@ -1,8 +1,15 @@
 persistence:
   pg_url: postgresql://vandelay_app:secret@postgres:5432/vandelay
+  redis:
+    host: redis
+    expires_in: 10
 integrations:
   vendors:
     one:
-      api_base_url: mock_api_one:80
+      service_class: Vendor1Service
+      api_base_url: http://mock_api_one:80
     two:
-      api_base_url: mock_api_two:80
+      service_class: Vendor2Service
+      api_base_url: http://mock_api_two:80
+    no_vendor:
+      service_class: NoVendorService

--- a/config.test.yml
+++ b/config.test.yml
@@ -1,8 +1,15 @@
 persistence:
   pg_url: postgresql://vandelay_app:secret@postgres-test:5432/vandelay_test
+  redis:
+    host: redis
+    expires_in: 1
 integrations:
   vendors:
     one:
-      api_base_url: mock_api_one:80
+      service_class: Vendor1Service
+      api_base_url: http://mock_api_one:80
     two:
-      api_base_url: mock_api_two:80
+      service_class: Vendor2Service
+      api_base_url: http://mock_api_two:80
+    no_vendor:
+      service_class: NoVendorService

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
     container_name: mock_api_two
     image: clue/json-server
     volumes:
-      - ./externals/mock_api_one:/data
+      - ./externals/mock_api_two:/data
     ports:
       - "3061:80"
 

--- a/lib/vandelay/integrations/base.rb
+++ b/lib/vandelay/integrations/base.rb
@@ -1,0 +1,35 @@
+require "net/http"
+require 'vandelay/services/cache_service'
+
+module Vandelay
+  module Integrations
+    class Base
+      def initialize(patient, url)
+        @patient = patient
+        @base_url = url
+        @cache_service = Vandelay::Services::CacheService.new("patient_record_#{patient.vendor_id}")
+      end
+
+      def get_records_from_provider
+        @cache_service.fetch_and_store do
+          uri = URI.parse(get_patient_url)
+          http = Net::HTTP.new(uri.host, uri.port)
+          request = Net::HTTP::Get.new(uri.request_uri)
+          request["Authorization"] = "Beater: #{get_token}"
+          response = http.request(request)
+          parsed_body = JSON.parse(response.body)
+          get_record_response(parsed_body)
+        end
+      end
+
+      private
+
+      def get_token
+        uri_token = URI.parse(get_token_url)
+        response = Net::HTTP.get_response(uri_token)
+        parsed_body = JSON.parse(response.body)
+        get_token_from_response(parsed_body)
+      end
+    end
+  end
+end

--- a/lib/vandelay/integrations/factory_service.rb
+++ b/lib/vandelay/integrations/factory_service.rb
@@ -1,0 +1,18 @@
+require 'vandelay/integrations/no_vendor_service'
+require 'vandelay/integrations/vendor1_service'
+require 'vandelay/integrations/vendor2_service'
+
+module Vandelay
+  module Integrations
+    class FactoryService
+
+      def self.create(patient)
+        vendor_name = patient.records_vendor || 'no_vendor'
+        service_configuration = Vandelay.config.dig('integrations', 'vendors', vendor_name)
+        url = service_configuration['api_base_url']
+        service_clazz = Object.const_get("Vandelay::Integrations::#{service_configuration['service_class']}")
+        service_clazz.new(patient, url)
+      end
+    end
+  end
+end

--- a/lib/vandelay/integrations/no_vendor_service.rb
+++ b/lib/vandelay/integrations/no_vendor_service.rb
@@ -1,0 +1,16 @@
+require "vandelay/integrations/base"
+
+module Vandelay
+  module Integrations
+    class NoVendorService < Base
+      def get_records_from_provider
+        {
+          "patient_id": @patient.vendor_id,
+          "province": nil,
+          "allergies": [],
+          "num_medical_visits": nil
+        }
+      end
+    end
+  end
+end

--- a/lib/vandelay/integrations/vendor1_service.rb
+++ b/lib/vandelay/integrations/vendor1_service.rb
@@ -1,0 +1,29 @@
+require "vandelay/integrations/base"
+
+module Vandelay
+  module Integrations
+    class Vendor1Service < Base
+
+      def get_token_from_response(parsed_body)
+        parsed_body['token']
+      end
+
+      def get_record_response(parsed_body)
+       {
+          "patient_id": parsed_body['id'],
+          "province": parsed_body['province'],
+          "allergies": parsed_body['allergies'],
+          "num_medical_visits": parsed_body['recent_medical_visits']
+        }
+      end
+
+      def get_token_url
+        "#{@base_url}/auth/1"
+      end
+
+      def get_patient_url
+        "#{@base_url}/patients/#{@patient.vendor_id}"
+      end
+    end
+  end
+end

--- a/lib/vandelay/integrations/vendor2_service.rb
+++ b/lib/vandelay/integrations/vendor2_service.rb
@@ -1,0 +1,30 @@
+require "vandelay/integrations/base"
+
+module Vandelay
+  module Integrations
+    class Vendor2Service < Base
+
+      def get_token_from_response(parsed_body)
+        parsed_body['auth_token']
+      end
+
+      def get_record_response(parsed_body)
+        {
+          "patient_id": parsed_body['id'],
+          "province": parsed_body['province_code'],
+          "allergies": parsed_body['allergies_list'],
+          "num_medical_visits": parsed_body['medical_visits_recently']
+        }
+      end
+
+      def get_token_url
+        "#{@base_url}/auth_tokens/1"
+      end
+
+      def get_patient_url
+        "#{@base_url}/records/#{@patient.vendor_id}"
+      end
+
+    end
+  end
+end

--- a/lib/vandelay/models/base.rb
+++ b/lib/vandelay/models/base.rb
@@ -9,7 +9,7 @@ module Vandelay
         data.each do |prop, val|
           self.instance_variable_set "@#{prop}", val
           self.class.class_eval do
-            define_method("#{prop}") { val }
+            define_method("#{prop}") { eval "@#{prop}" }
           end
         end
       end

--- a/lib/vandelay/models/base.rb
+++ b/lib/vandelay/models/base.rb
@@ -9,7 +9,7 @@ module Vandelay
         data.each do |prop, val|
           self.instance_variable_set "@#{prop}", val
           self.class.class_eval do
-            define_method("#{prop}") { eval "@#{prop}" }
+            attr_accessor prop
           end
         end
       end

--- a/lib/vandelay/rest.rb
+++ b/lib/vandelay/rest.rb
@@ -1,4 +1,4 @@
-Dir[File.dirname(__FILE__) + '/rest/**.rb'].each {|rb| require_relative rb }
+Dir[File.dirname(__FILE__) + '/rest/**.rb'].each {|rb| require_relative rb}
 
 module Vandelay
   module REST

--- a/lib/vandelay/rest/patients_patient.rb
+++ b/lib/vandelay/rest/patients_patient.rb
@@ -4,8 +4,42 @@ require 'vandelay/services/patient_records'
 module Vandelay
   module REST
     module PatientsPatient
+      def self.validate_and_grab_patient(id_patient)
+        if id_patient == 0
+          return { status: 400, error: 'malformed_url - invalid id parameter' }
+        end
+        service = Vandelay::Services::Patients.new
+        result = service.retrieve_one(id_patient)
+        if result.nil?
+          { success: false, status: 404, error: 'patient not found' }
+        else
+          { success: true, status: 200, record: result }
+        end
+      end
+
       def self.registered(app)
-        # add endpoint code here
+        app.get '/patients/:id' do
+          result = Vandelay::REST::PatientsPatient::validate_and_grab_patient(params[:id].to_i)
+          status result[:status]
+          if result[:success]
+            json(result[:record].to_h)
+          else
+            json({error: result[:error]})
+          end
+        end
+
+        app.get '/patients/:patient_id/record' do
+          result = Vandelay::REST::PatientsPatient::validate_and_grab_patient(params[:patient_id].to_i)
+          status result[:status]
+          if result[:success]
+            patient = result[:record]
+            service = Vandelay::Services::PatientRecords.new
+            records = service.retrieve_record_for_patient(patient)
+            json(records)
+          else
+            json({error: result[:error]})
+          end
+        end
       end
     end
   end

--- a/lib/vandelay/services/cache_service.rb
+++ b/lib/vandelay/services/cache_service.rb
@@ -1,0 +1,27 @@
+require 'redis'
+
+module Vandelay
+  module Services
+    class CacheService
+
+      def initialize(cache_key)
+        redis_config = Vandelay.config.dig('persistence', 'redis')
+        @cache_key = cache_key
+        @client = Redis.new(host: redis_config['host'])
+        @expire_in = redis_config['expires_in'].to_i
+      end
+
+      def fetch_and_store
+        raise 'A block should be given' unless block_given?
+        value = @client.get(@cache_key)
+        if value.nil?
+          value = yield
+          @client.setex(@cache_key, @expire_in, value.to_json) unless value.nil?
+          value
+        else
+          JSON.parse(value)
+        end
+      end
+    end
+  end
+end

--- a/lib/vandelay/services/patient_records.rb
+++ b/lib/vandelay/services/patient_records.rb
@@ -1,8 +1,11 @@
+require 'vandelay/integrations/factory_service'
+
 module Vandelay
   module Services
     class PatientRecords
       def retrieve_record_for_patient(patient)
-        # add logic here
+        service = Vandelay::Integrations::FactoryService.create(patient)
+        service.get_records_from_provider
       end
     end
   end

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe Vandelay::Models::Patient do
+
+  it 'loads all patients' do
+    patients = described_class.all
+    expect(patients.count).to eq(3)
+    expect(patients.map{|x| x.vendor_id}.compact.sort).to eq(["16", "743"])
+  end
+
+  it 'loads a patient by id' do
+    patient = described_class.with_id(1)
+    expect(patient.id).to eq("1")
+  end
+end

--- a/spec/rest/app_spec.rb
+++ b/spec/rest/app_spec.rb
@@ -1,0 +1,118 @@
+RSpec.describe 'Vandelay API endpoints' do
+  def app
+    #Sinatra::Application
+    RESTServer
+  end
+
+  def parsed_body
+    JSON.parse(last_response.body)
+  end
+
+  before do
+    get uri
+  end
+
+  context 'api system path' do
+    let(:uri) { '/' }
+
+    it "responds with ok status" do
+      expect(last_response).to be_ok
+      expect(parsed_body['service_name']).to eq("Vandelay Industries")
+    end
+  end
+
+  context 'api system path' do
+    let(:uri) { '/system_status' }
+
+    it "responds with ok status" do
+      expect(last_response).to be_ok
+    end
+  end
+
+  context "/patients endpoint" do
+    let(:uri) { '/patients' }
+
+    it "responds with ok status and patient list in response body" do
+      expect(last_response).to be_ok
+      expect(parsed_body.count).to eq(3)
+      expect(parsed_body.map{|x| x['vendor_id']}.compact.sort).to eq(["16", "743"])
+    end
+  end
+
+  context "/patients/:id endpoint" do
+
+    context 'existing patient' do
+      let(:uri) { "/patients/2" }
+
+      it "responds with ok status and a patient data in response body" do
+        expect(last_response).to be_ok
+        expect(parsed_body['full_name']).to eq("Cosmo Kramer")
+        expect(parsed_body['records_vendor']).to eq("one")
+      end
+    end
+
+    context 'non existing patient' do
+      let(:uri) { "/patients/999" }
+
+      it "responds with status 404" do
+        expect(last_response.status).to eq(404)
+      end
+    end
+  end
+
+  context "/patients/:id/record endpoint" do
+    let(:uri) { "/patients/#{id_patient}/record" }
+
+    context "patient with no vendor record" do
+      let(:id_patient) { 1 }
+
+      it "responds with ok status and a nil data in response body" do
+        expect(last_response).to be_ok
+        expect(parsed_body['patient_id']).to be_nil
+        expect(parsed_body['province']).to be_nil
+        expect(parsed_body['num_medical_visits']).to be_nil
+        expect(parsed_body['allergies']).to be_empty
+      end
+    end
+
+    context "patient with vendor 'one' record" do
+      let(:id_patient) { 2 }
+
+      it "responds with ok status and a record data in response body" do
+        expect(last_response).to be_ok
+        expect(parsed_body['patient_id']).to eq("743")
+        expect(parsed_body['province']).to eq("QC")
+        expect(parsed_body['num_medical_visits']).to eq(1)
+        expect(parsed_body['allergies']).to eq(["work", "conformity", "paying taxes"])
+      end
+    end
+
+    context "patient with vendor 'two' record" do
+      let(:id_patient) { 3 }
+
+      it "responds with ok status and a record data in response body" do
+        expect(last_response).to be_ok
+        expect(parsed_body['patient_id']).to eq("16")
+        expect(parsed_body['province']).to eq("ON")
+        expect(parsed_body['num_medical_visits']).to eq(17)
+        expect(parsed_body['allergies']).to eq(["hair", "mean people", "paying the bill"])
+      end
+    end
+
+    context 'invalid patient' do
+      let(:id_patient) { 'xxx' }
+
+      it "responds with status 400" do
+        expect(last_response.status).to eq(400)
+      end
+    end
+
+    context 'non existing patient' do
+      let(:id_patient) { '999' }
+
+      it "responds with status 404" do
+        expect(last_response.status).to eq(404)
+      end
+    end
+  end
+end

--- a/spec/services/cache_service_spec.rb
+++ b/spec/services/cache_service_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Vandelay::Services::CacheService do
+
+  let(:cache_key) { 'test_redis_key' }
+
+  context 'with a cached value cache' do
+    before do
+      described_class.new(cache_key).fetch_and_store { 5 }
+    end
+
+    it 'gets cached value' do
+      value = described_class.new(cache_key).fetch_and_store { 15 }
+      expect(value).to eq(5)
+    end
+  end
+end

--- a/spec/services/patient_records_spec.rb
+++ b/spec/services/patient_records_spec.rb
@@ -1,0 +1,13 @@
+
+RSpec.describe Vandelay::Services::PatientRecords do
+  let(:patient_service) { Vandelay::Services::Patients.new }
+  let(:service) { described_class.new }
+
+  it 'loads a patient by id' do
+    patient = patient_service.retrieve_one(2)
+    record = service.retrieve_record_for_patient(patient)
+    expect(record["patient_id"]).to eq("743")
+    expect(record["province"]).to eq("QC")
+    expect(record["num_medical_visits"]).to eq(1)
+  end
+end

--- a/spec/services/patients_spec.rb
+++ b/spec/services/patients_spec.rb
@@ -1,0 +1,15 @@
+
+RSpec.describe Vandelay::Services::Patients do
+  let(:service) { described_class.new }
+
+  it 'loads all patients' do
+    patients = service.retrieve_all
+    expect(patients.count).to eq(3)
+    expect(patients.map{|x| x.vendor_id}.compact.sort).to eq(["16", "743"])
+  end
+
+  it 'loads a patient by id' do
+    patient = service.retrieve_one(1)
+    expect(patient.id).to eq("1")
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,21 @@
+require 'simplecov'
+SimpleCov.start
+
+ENV['APP_ENV'] = 'test'
+
+require './server'
+require 'rack/test'
+
+RSpec.configure do |config|
+  config.include Rack::Test::Methods
+
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+end


### PR DESCRIPTION
This is the solution presented by Hernan Velasquez for the ruby take home challenge. As requested, I'm opening a PR for your consideration, and below you'll find a guide for reading the PR.

# Requirements implementation walkthrough

The exercise asked to implement 4 requirements. Solution for each one its explained below:

1. Endpoint for fetching a patient by id is Implemented in `/lib/vandelay/rest/patients_patient.rb` as requested [here](https://github.com/AkiraMD/ruby-senior-take-home-assignment/pull/10/files#diff-cee117d88bf2743bb99557c2ca2b4ede8e7f779084623c7dff95ac5e353a00e5R21). All cases including errors are considered returning proper http statuses / response bodies.

2. Endpoint for fetching records for a patient is implemented [here](https://github.com/AkiraMD/ruby-senior-take-home-assignment/pull/10/files#diff-cee117d88bf2743bb99557c2ca2b4ede8e7f779084623c7dff95ac5e353a00e5R31)

The integration service was designed as:

![image](https://github.com/AkiraMD/ruby-senior-take-home-assignment/assets/1505165/bfb91ea4-046e-4d38-801c-c31e3d506c72)

`PatientRecords` service will request a vendor factory to return the correct vendor service based on patient's `vendor_name` as you can see [here](https://github.com/AkiraMD/ruby-senior-take-home-assignment/pull/10/files#diff-7041195da88bd21ca505d82308065388528af76d85567216032c8e2b1b259da4R9). Vendor names and vendor services classes are mapped in the configuration yml file as you can see [here](https://github.com/AkiraMD/ruby-senior-take-home-assignment/pull/10/files#diff-37a37578aca948bc92ac0fdfd0e77359282b2e0a78b2b6481f4d61878781052fR9).

`NoVendorService` exists for patients that have no vendor (`vendor_name = nil`). It just returns a hash with nil values to defined keys as you can see [here](https://github.com/AkiraMD/ruby-senior-take-home-assignment/pull/10/files#diff-82ea2cfe61b61f06a762b99ef11eb0f2937cfb4fc5dc659546240b37cc756a0eR1). No need to authenticate or call any 3rd party vendor here.

Authentication is handled in `Vandelay::Integrations::Base#get_records_from_provider` [here](https://github.com/AkiraMD/ruby-senior-take-home-assignment/pull/10/files#diff-f2d715fcd5b6815b93874f722dec71cadbc574255de2e161a164c965e664793bR15). Reason to do this in the base class is because requirements says vendor 1 and 2 authenticates in the same way (via `Authorization` header). If we want to extend this to a vendor authenticating in another way, overriding `get_records_from_provider` will do the tick for that vendor service class.


3. Cache service used by integration services is located [here](https://github.com/AkiraMD/ruby-senior-take-home-assignment/pull/10/files#diff-f172d84b3aed50b7eb749b77e1e61d7a035892f0cadcd7966925f1932939b95cR1). You will see that redis connection parameters are properly set in configuration yml file, as well as expire time (suggested for 10 minutes but I left it in 10 seconds for dev and 1 second for test.. you can change it easily though).

4. I used rspec as testing framework and simple_cov for coverage report (I'm presenting a 100% coverage). To run the tests, just locate the container id for `rest_server`, grab a shell and run `rspec` as:

```
docker ps
docker exec -it <container id fetched from above> bash
# Inside the container
rspec
```
Here's an example:
![image](https://github.com/AkiraMD/ruby-senior-take-home-assignment/assets/1505165/7a9b9e43-2e1c-4411-b494-ff9ce88b3581)

UPDATE [Feb 29]: specs are now pushed and available under /spec directory in this PR. You will see unit and integration tests on patients model and services class, as well as integration tests on the rest endpoints. My apologies for the omission.

# Bugfixes

There are 2 bugfixes I suggest the maintainers should look into for future candidates using this test:

1. In the docker compose file, the vendor's `mock_api_two` container is mapped to the wrong volume. This is fixed [here](https://github.com/AkiraMD/ruby-senior-take-home-assignment/pull/10/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R63)  

2. In `lib/vandelay/models/base.rb` it is given this code:

```
self.class.class_eval do
  define_method("#{prop}") { val }
end
```
This is incorrect. If you define `prop` methods at class level returning `val`, it will override to the last `val` each time this code is called, therefore if you're calling methods like `Vandelay::Models::Patient.all` you will see weird behaviour like this one:
![image](https://github.com/AkiraMD/ruby-senior-take-home-assignment/assets/1505165/7a05151e-f460-463e-81f0-e36b2e0629d1)

One solution is given [here](https://github.com/AkiraMD/ruby-senior-take-home-assignment/pull/10/files#diff-773ab30ff84175afedced53234a51e1f005ae68ee9b5b26351027e6e50697ab8R12)

# Final notes / Questions?

You'll be able to run this solution by cloning my branch, building and running the docker images using the same instructions you posted on the exercise. It's important to build the images since I'm not including the `Gemfile.lock` (except for including rspec dependencies) in the PR (for some reasons its started including arm packages in the file so I prefer to leave it).

Feel free to reach me if you have questions or comments about this solution. I'll do my best to review or answer any notes or comments on posted on this PR. Alternatively, you can reach me at hernamvel@gmail.com.

Thanks. 

