### PR TITLE
Jts/interview/ruby take home

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ build-iPhoneSimulator/
 
 /postgres-data
 /postgres-data-test
+.tool-versions

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,6 @@ gem 'sinatra-contrib'
 gem 'puma'
 gem 'rackup'
 gem 'irb'
+gem 'test-unit'
+gem 'rack-test'
+

--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,4 @@ gem 'rackup'
 gem 'irb'
 gem 'test-unit'
 gem 'rack-test'
-
+gem 'rest-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,21 @@ GEM
   remote: https://rubygems.org/
   specs:
     connection_pool (2.4.1)
+    domain_name (0.6.20240107)
+    http-accept (1.7.0)
+    http-cookie (1.0.6)
+      domain_name (~> 0.5)
     io-console (0.6.0)
     irb (1.8.1)
       rdoc
       reline (>= 0.3.8)
+    mime-types (3.5.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2024.0604)
     multi_json (1.15.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
+    netrc (0.11.0)
     nio4r (2.5.9)
     pg (1.5.4)
     power_assert (2.0.3)
@@ -32,6 +40,11 @@ GEM
       connection_pool
     reline (0.3.8)
       io-console (~> 0.5)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     ruby2_keywords (0.0.5)
     sinatra (3.1.0)
       mustermann (~> 3.0)
@@ -52,6 +65,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-23
   x86_64-darwin-21
 
 DEPENDENCIES
@@ -61,6 +75,7 @@ DEPENDENCIES
   rack-test
   rackup
   redis
+  rest-client
   sinatra (~> 3.1.0)
   sinatra-contrib
   test-unit

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
       ruby2_keywords (~> 0.0.1)
     nio4r (2.5.9)
     pg (1.5.4)
+    power_assert (2.0.3)
     psych (5.1.0)
       stringio
     puma (6.3.1)
@@ -18,6 +19,8 @@ GEM
     rack (2.2.8)
     rack-protection (3.1.0)
       rack (~> 2.2, >= 2.2.4)
+    rack-test (2.1.0)
+      rack (>= 1.3)
     rackup (1.0.0)
       rack (< 3)
       webrick
@@ -42,6 +45,8 @@ GEM
       sinatra (= 3.1.0)
       tilt (~> 2.0)
     stringio (3.0.8)
+    test-unit (3.5.7)
+      power_assert
     tilt (2.3.0)
     webrick (1.8.1)
 
@@ -53,10 +58,12 @@ DEPENDENCIES
   irb
   pg (~> 1.5.3)
   puma
+  rack-test
   rackup
   redis
   sinatra (~> 3.1.0)
   sinatra-contrib
+  test-unit
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/api_test.rb
+++ b/api_test.rb
@@ -4,6 +4,7 @@ require_relative './server'
 require 'test/unit'
 require 'rack/test'
 require 'json'
+require 'rest-client'
 
 class VandelayTest < Test::Unit::TestCase
   include Rack::Test::Methods
@@ -35,12 +36,52 @@ class VandelayTest < Test::Unit::TestCase
   end
 
   def test_single_patient_returns_404
-    get "/patients/patient/", "CONTENT_TYPE" => "application/json"
+    get "/patients/patient/500", "CONTENT_TYPE" => "application/json"
+    assert_equal 404, last_response.status
+  end
+
+  def test_single_patient_returns_400
+    get "/patients/patient/friday", "CONTENT_TYPE" => "application/json"
+    assert_equal 400, last_response.status
+  end
+
+  def test_vendor_one_existing_patient
+    get "/patients/2/record", "CONTENT_TYPE" => "application/json"
+    assert last_response.ok?
+    result = JSON.parse(last_response.body)
+
+    assert result.keys.include?('patient_id')
+    assert result.keys.include?('province')
+    assert result.keys.include?('allergies')
+    assert result.keys.include?('num_medical_visits')
+    assert_equal 2, result["patient_id"]
+    assert_equal "QC", result["province"]
+    assert_equal ["work", "conformity", "paying taxes"], result["allergies"] 
+    assert_equal 1, result["num_medical_visits"]
+  end
+
+  def test_vendor_two_existing_patient
+    get "/patients/3/record", "CONTENT_TYPE" => "application/json"
+    assert last_response.ok?
+
+    result = JSON.parse(last_response.body)
+    assert result.keys.include?('patient_id')
+    assert result.keys.include?('province')
+    assert result.keys.include?('allergies')
+    assert result.keys.include?('num_medical_visits')
+    assert_equal 3, result["patient_id"]
+    assert_equal "ON", result["province"]
+    assert_equal ["hair", "mean people", "paying the bill"], result["allergies"] 
+    assert_equal 17, result["num_medical_visits"]
+  end
+
+  def test_patient_record_null_vendor
+    get "/patients/1/record", "CONTENT_TYPE" => "application/json"
     assert_equal last_response.status, 404
   end
 
-  def test_single_patient_word_returns_404
-    get "/patients/patient/friday", "CONTENT_TYPE" => "application/json"
-    assert_equal last_response.status, 404
+  def test_patient_record_bad_id
+    get "/patients/friday/record", "CONTENT_TYPE" => "application/json"
+    assert_equal last_response.status, 400
   end
 end

--- a/api_test.rb
+++ b/api_test.rb
@@ -1,0 +1,36 @@
+ENV['APP_ENV'] = 'test'
+
+require_relative './server'
+require 'test/unit'
+require 'rack/test'
+require 'json'
+
+class VandelayTest < Test::Unit::TestCase
+  include Rack::Test::Methods
+
+  def app
+    @app = RESTServer
+  end
+
+  def test_it_returns_service_name
+    data = '{"service_name":"Vandelay Industries"}'
+    get '/', "CONTENT_TYPE" => "application/json"
+    assert last_response.ok?
+    assert_equal JSON.parse(data.to_json), last_response.body
+  end
+
+  def test_it_returns_all_patients
+    data = Vandelay::REST::Patients.patients_srvc.retrieve_all
+    get '/patients', "CONTENT_TYPE" => "application/json"
+    assert last_response.ok?
+    assert_equal data.to_json, last_response.body
+  end
+
+  def test_it_returns_existing_patient
+    patient_id = 1
+    data = Vandelay::Models::Patient.with_id(patient_id)
+    get "/patients/#{patient_id}", "CONTENT_TYPE" => "application/json"
+    assert last_response.ok?
+    assert_equal data.to_h.to_json, last_response.body
+  end
+end

--- a/api_test.rb
+++ b/api_test.rb
@@ -29,7 +29,7 @@ class VandelayTest < Test::Unit::TestCase
   def test_it_returns_existing_patient
     patient_id = 1
     data = Vandelay::Models::Patient.with_id(patient_id)
-    get "/patients/#{patient_id}", "CONTENT_TYPE" => "application/json"
+    get "/patients/patient/#{patient_id}", "CONTENT_TYPE" => "application/json"
     assert last_response.ok?
     assert_equal data.to_h.to_json, last_response.body
   end

--- a/api_test.rb
+++ b/api_test.rb
@@ -33,4 +33,14 @@ class VandelayTest < Test::Unit::TestCase
     assert last_response.ok?
     assert_equal data.to_h.to_json, last_response.body
   end
+
+  def test_single_patient_returns_404
+    get "/patients/patient/", "CONTENT_TYPE" => "application/json"
+    assert_equal last_response.status, 404
+  end
+
+  def test_single_patient_word_returns_404
+    get "/patients/patient/friday", "CONTENT_TYPE" => "application/json"
+    assert_equal last_response.status, 404
+  end
 end

--- a/boot.rb
+++ b/boot.rb
@@ -5,6 +5,8 @@ $: << BASE_PATH + "/lib"
 
 require 'vandelay'
 require 'vandelay/util/db'
+require 'vandelay/util/cache'
 require 'vandelay/models'
+require 'vandelay/integrations/base'
 
 Vandelay::Util::DB.verify_connection! unless Vandelay::Util::DB.connection_verified?

--- a/config.dev.yml
+++ b/config.dev.yml
@@ -1,5 +1,6 @@
 persistence:
   pg_url: postgresql://vandelay_app:secret@postgres:5432/vandelay
+  redis_url: redis://redis:6379/0
 integrations:
   vendors:
     one:

--- a/config.test.yml
+++ b/config.test.yml
@@ -1,5 +1,6 @@
 persistence:
   pg_url: postgresql://vandelay_app:secret@postgres-test:5432/vandelay_test
+  redis_url: redis://redis:6379/0
 integrations:
   vendors:
     one:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
     container_name: mock_api_two
     image: clue/json-server
     volumes:
-      - ./externals/mock_api_one:/data
+      - ./externals/mock_api_two:/data
     ports:
       - "3061:80"
 

--- a/lib/vandelay/integrations/base.rb
+++ b/lib/vandelay/integrations/base.rb
@@ -1,0 +1,27 @@
+require 'rest-client'
+
+module Vandelay
+    module Integrations
+        class Base
+            def api_base_url
+                'http://' + Vandelay.config.dig('integrations', 'vendors', vendor_name, 'api_base_url')
+            end
+            
+
+            def get_patient_record(vendor_id)
+                uri = URI.parse(patient_record_url(vendor_id))
+                headers = {}
+                headers.merge({'Authorization' => "Bearer #{get_auth_token}"})
+                request = RestClient.get(patient_record_url(vendor_id), headers)
+                JSON.parse(request.body)
+            end
+
+            private
+
+            def get_auth_token
+                request = RestClient.get(auth_token_url)
+                JSON.parse(request.body)
+            end
+        end
+    end
+end

--- a/lib/vandelay/integrations/one.rb
+++ b/lib/vandelay/integrations/one.rb
@@ -1,0 +1,28 @@
+module Vandelay
+    module Integrations
+            class One < Vandelay::Integrations::Base
+
+                def vendor_name
+                    "one"
+                end
+
+                def patient_record_url(patient_id)
+                    "#{api_base_url}/patients/#{patient_id}"
+                end
+
+                def auth_token_url
+                    "#{api_base_url}/auth/1"
+                end
+
+                def get_patient_record(vendor_id)
+                    data = super
+                    {
+                      province: data['province'],
+                      allergies: data['allergies'],
+                      num_medical_visits: data['recent_medical_visits']
+                    }
+                end
+
+            end
+    end
+end

--- a/lib/vandelay/integrations/two.rb
+++ b/lib/vandelay/integrations/two.rb
@@ -1,0 +1,27 @@
+module Vandelay
+    module Integrations
+            class Two < Vandelay::Integrations::Base
+
+                def vendor_name
+                    "two"
+                end
+
+                def patient_record_url(patient_id)
+                    "#{api_base_url}/records/#{patient_id}"
+                end
+
+                def auth_token_url
+                    "#{api_base_url}/auth_tokens/1"
+                end
+
+                def get_patient_record(vendor_id)
+                    data = super
+                    {
+                      province: data['province_code'],
+                      allergies: data['allergies_list'],
+                      num_medical_visits: data['medical_visits_recently']
+                    }
+                end
+            end
+    end
+end

--- a/lib/vandelay/rest/patients_patient.rb
+++ b/lib/vandelay/rest/patients_patient.rb
@@ -10,9 +10,13 @@ module Vandelay
 
       def self.registered(app)
         app.get '/patients/patient/:patient_id' do
-          patient_id = params[:patient_id]
+          patient_id = params[:patient_id].to_i
           result = Vandelay::REST::Patients.patients_srvc.retrieve_one(patient_id)
-          json(result.to_h)
+          if result
+            json(result.to_h)
+          else
+            status 404
+          end
         end
       end
     end

--- a/lib/vandelay/rest/patients_patient.rb
+++ b/lib/vandelay/rest/patients_patient.rb
@@ -10,13 +10,11 @@ module Vandelay
 
       def self.registered(app)
         app.get '/patients/patient/:patient_id' do
-          patient_id = params[:patient_id].to_i
+          patient_id = Integer(params[:patient_id] , exception: false)
+          halt 400 if patient_id.nil?
           result = Vandelay::REST::Patients.patients_srvc.retrieve_one(patient_id)
-          if result
-            json(result.to_h)
-          else
-            status 404
-          end
+          halt 404 unless result
+          json(result.to_h)
         end
       end
     end

--- a/lib/vandelay/rest/patients_patient.rb
+++ b/lib/vandelay/rest/patients_patient.rb
@@ -4,8 +4,16 @@ require 'vandelay/services/patient_records'
 module Vandelay
   module REST
     module PatientsPatient
+      def self.patients_srvc
+        @patients_srvc ||= Vandelay::Services::Patients.new
+      end
+
       def self.registered(app)
-        # add endpoint code here
+        app.get '/patients/patient/:patient_id' do
+          patient_id = params[:patient_id]
+          result = Vandelay::REST::Patients.patients_srvc.retrieve_one(patient_id)
+          json(result.to_h)
+        end
       end
     end
   end

--- a/lib/vandelay/rest/patients_patient_record.rb
+++ b/lib/vandelay/rest/patients_patient_record.rb
@@ -1,0 +1,28 @@
+require 'vandelay/services/patients'
+require 'vandelay/services/patient_records'
+
+module Vandelay
+  module REST
+    module PatientsPatientRecord
+        def self.patients_srvc
+            @patients_srvc ||= Vandelay::Services::Patients.new
+        end
+        def self.patients_record_srvc
+            @patient_record_srvc ||= Vandelay::Services::PatientRecords.new
+        end
+
+        def self.registered(app)
+            app.get '/patients/:patient_id/record' do
+                patient_id = Integer(params[:patient_id] , exception: false)
+                halt 400 if patient_id.nil?
+                patient = Vandelay::REST::Patients.patients_srvc.retrieve_one(patient_id)
+                vendor_patient_record = Vandelay::REST::PatientsPatientRecord.patients_record_srvc.retrieve_record_for_patient(patient.id, patient.records_vendor, patient.vendor_id)
+                halt 404 unless vendor_patient_record
+                result = {:patient_id => patient_id}
+                result.merge!(vendor_patient_record)
+                json(result)
+            end
+        end
+    end
+  end
+end

--- a/lib/vandelay/services/patient_records.rb
+++ b/lib/vandelay/services/patient_records.rb
@@ -1,8 +1,29 @@
+require 'vandelay/integrations/base'
+require 'vandelay/integrations/one'
+require 'vandelay/integrations/two'
+require 'vandelay/models/patient'
+require 'redis'
+
 module Vandelay
   module Services
     class PatientRecords
-      def retrieve_record_for_patient(patient)
-        # add logic here
+      def retrieve_record_for_patient(patient_id, records_vendor, vendor_id)
+        cache = Vandelay::Util::Cache.new
+        cached_record = cache.get("#{patient_id}")
+
+        return cached_record if cached_record
+
+        if records_vendor == "one"
+          vendor_class = Vandelay::Integrations::One.new
+        elsif records_vendor == "two"
+          vendor_class = Vandelay::Integrations::Two.new
+        else
+          return
+        end
+        
+        vendor_record = vendor_class.get_patient_record(vendor_id)
+        cache.set("#{patient_id}", vendor_record) if vendor_record
+        vendor_record
       end
     end
   end

--- a/lib/vandelay/util/cache.rb
+++ b/lib/vandelay/util/cache.rb
@@ -1,9 +1,18 @@
-require 'redis'
-
 module Vandelay
   module Util
     class Cache
-      # your code here
+      def initialize
+        @redis = Redis.new(url: Vandelay.config.dig("persistence", "redis_url"))
+      end
+
+      def set(key, value, duration=600)
+        @redis.set key, value
+        @redis.expire key, duration
+      end
+
+      def get(key)
+        @redis.get key
+      end
     end
   end
 end


### PR DESCRIPTION
This pull request contains the following changes

- Integrations base class
- Classes for Vendors One and Two
- Cache Utility Class
- Patient Record Endpoint
- Patient Record Service
- Integration tests using test/unit and rack testing gems
- updated dev configuration to point to correct mock api service

I decided to use test-unit as opposed to Rspec because this is a Sinatra app, so I wanted to use a test framework that was as lightweight as possible. If this was a longer term project, I would opt for a more thorough unit testing regime, providing coverage for all models, services, and utility classes. In keeping with Sinatra's lightweight nature however, I felt that a single file containing integration tests for all of my changes suited the project more completely.

The specs can be run by logging into the bash console of rest-server:
`
 docker exec -it rest_server /bin/bash`
 
 And running the following command

`bundle exec ruby api_test.rb`