### PR TITLE
td/interview/ruby-take-home

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,10 @@ gem 'sinatra-contrib'
 gem 'puma'
 gem 'rackup'
 gem 'irb'
+
+group :test do
+  gem 'rspec'
+  gem 'rack-test'
+  gem 'webmock', require: 'webmock/rspec'
+end
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
     container_name: mock_api_two
     image: clue/json-server
     volumes:
-      - ./externals/mock_api_one:/data
+      - ./externals/mock_api_two:/data
     ports:
       - "3061:80"
 

--- a/lib/vandelay/integrations/api1.rb
+++ b/lib/vandelay/integrations/api1.rb
@@ -1,0 +1,30 @@
+require 'vandelay/integrations/base'
+
+module Vandelay
+  module Integrations
+    class Api1 < Vandelay::Integrations::Base
+
+      attr_reader :base_url, :auth_id, :auth_token, :auth_path, :records_path,:record_path
+
+      def initialize
+        @auth_path =  "/auth"
+        @auth_id =  "1" # in real life auth_id would come from either config or be passed down
+        @records_path = "/patients/"
+        @record_path = "/patients/"
+        @token_ident = "token"
+        @base_url =  Vandelay.config["integrations"]["vendors"]["one"]["api_base_url"]
+        @auth_token = fetch_auth_token
+      end
+
+      def get_mapped_record(id)
+        data=self.get_record(id)
+        {
+          "patient_id": data["id"],
+          "province": data["province"],
+          "allergies": data["allergies"],
+          "num_medical_visits": data["recent_medical_visits"]
+        }
+       end
+    end
+  end
+end

--- a/lib/vandelay/integrations/api2.rb
+++ b/lib/vandelay/integrations/api2.rb
@@ -7,7 +7,7 @@ module Vandelay
       attr_reader :base_url,  :auth_id, :auth_token, :auth_path, :records_path,:record_path
 
       def initialize
-        @auth_path =  "/auth_tokens/1"
+        @auth_path =  "/auth_tokens"
         @records_path = "/records/"
         @auth_id =  "1" # in real life auth_id would come from either config or be passed down
         @record_path = "/records/"

--- a/lib/vandelay/integrations/api2.rb
+++ b/lib/vandelay/integrations/api2.rb
@@ -1,0 +1,30 @@
+require 'vandelay/integrations/base'
+
+module Vandelay
+  module Integrations
+    class Api2 < Vandelay::Integrations::Base
+
+      attr_reader :base_url,  :auth_id, :auth_token, :auth_path, :records_path,:record_path
+
+      def initialize
+        @auth_path =  "/auth_tokens/1"
+        @records_path = "/records/"
+        @auth_id =  "1" # in real life auth_id would come from either config or be passed down
+        @record_path = "/records/"
+        @token_ident = "auth_token"
+        @base_url =  Vandelay.config["integrations"]["vendors"]["two"]["api_base_url"]
+        @auth_token = fetch_auth_token
+      end
+
+      def get_mapped_record(id)
+        data=get_record(id)
+        {
+          "patient_id": data["id"],
+          "province": data["province_code"],
+          "allergies": data["allergies_list"],
+          "num_medical_visits": data["medical_visits_recently"]
+        }
+       end
+    end
+  end
+end

--- a/lib/vandelay/integrations/base.rb
+++ b/lib/vandelay/integrations/base.rb
@@ -26,7 +26,7 @@ module Vandelay
          token = JSON.parse(response.body)[@token_ident]
          token
        rescue StandardError => e
-         raise HttpRequestError.new(response), "Auth request failed: #{e.message}"
+         raise "Auth request failed: #{e.message}"
        end
      end
 
@@ -42,7 +42,7 @@ module Vandelay
          response = Net::HTTP.get_response(uri, get_auth_headers)
          JSON.parse(response.body)
        rescue StandardError => e
-         raise HttpRequestError.new(response), "request failed: #{e.message}"
+         raise "Request failed: #{e.message}"
        end
      end
 

--- a/lib/vandelay/integrations/base.rb
+++ b/lib/vandelay/integrations/base.rb
@@ -1,0 +1,65 @@
+require 'json'
+require 'uri'
+require 'net/http'
+
+module Vandelay
+ module Integrations
+   class Base
+
+     attr_reader :base_url, :auth_token, :auth_id, :auth_path, :records_path,:record_path,:token_ident
+
+     def initialize
+       @auth_path =  ""
+       @auth_id =  ""
+       @records_path = ""
+       @record_path = ""
+       @base_url =  ""
+       @token_ident =  ""
+       @auth_token = fetch_auth_token
+     end
+
+     def fetch_auth_token
+       uri = URI("http://#{base_url}#{auth_path}/#{auth_id}")
+
+       begin
+         response = Net::HTTP.get_response(uri)
+         token = JSON.parse(response.body)[@token_ident]
+         token
+       rescue StandardError => e
+         raise HttpRequestError.new(response), "Auth request failed: #{e.message}"
+       end
+     end
+
+     def get_auth_headers
+       headers = {}
+       headers['Authorization'] = "Bearer #{@auth_token}" unless @auth_token.nil? || @auth_token.empty?
+       headers
+     end
+
+     def get_record(id)
+       uri = URI("http://#{base_url}#{records_path}#{id}")
+       begin
+         response = Net::HTTP.get_response(uri, get_auth_headers)
+         JSON.parse(response.body)
+       rescue StandardError => e
+         raise HttpRequestError.new(response), "request failed: #{e.message}"
+       end
+     end
+
+     def get_mapped_record(id)
+      data=self.get_record(id)
+      {}
+     end
+
+     def get_all_records
+       uri = URI("http://#{base_url}#{record_path}")
+       begin
+         response = Net::HTTP.get_response(uri, get_auth_headers)
+         JSON.parse(response.body)
+       rescue StandardError => e
+         raise HttpRequestError.new(response), "request failed: #{e.message}"
+       end
+     end
+   end
+ end
+end

--- a/lib/vandelay/models/base.rb
+++ b/lib/vandelay/models/base.rb
@@ -22,7 +22,7 @@ module Vandelay
         end
       end
 
-      def to_json(_opts)
+      def to_json(_opts = {})
         JSON.dump(self.to_h)
       end
 

--- a/lib/vandelay/models/patient.rb
+++ b/lib/vandelay/models/patient.rb
@@ -14,13 +14,13 @@ module Vandelay
 
       def self.with_id(patient_id)
         result = self.with_connection do |conn|
-          conn.exec_params("SELECT * FROM patients WHERE id = $1::integer", [ patient_id ]).to_a[0]
+            conn.exec_params("SELECT * FROM patients WHERE id = $1::integer", [ patient_id ]).to_a[0]
         end
+
         return nil if result.nil?
 
-        Vandelay::Models::Patient.new(**result)
+        return Vandelay::Models::Patient.new(**result)
       end
-
     end
   end
 end

--- a/lib/vandelay/rest/patients_patient.rb
+++ b/lib/vandelay/rest/patients_patient.rb
@@ -5,7 +5,23 @@ module Vandelay
   module REST
     module PatientsPatient
       def self.registered(app)
-        # add endpoint code here
+        app.get '/patients/patient/:patient_id' do
+          begin
+            json(Vandelay::Services::Patients.new.retrieve_one(params[:patient_id]))
+          rescue
+            halt 404, json({ error: 'Record not found' })
+          end
+        end
+
+        app.get '/patients/:patient_id/record' do
+          begin
+            result = {}
+            results=Vandelay::Services::PatientRecords.new.retrieve_record_for_patient(params[:patient_id])
+            JSON(results)
+          rescue
+            halt 404, json({ error: 'Record not found' })
+          end
+        end
       end
     end
   end

--- a/lib/vandelay/services/patient_records.rb
+++ b/lib/vandelay/services/patient_records.rb
@@ -11,6 +11,8 @@ module Vandelay
         caching = Vandelay::Util::Cache.new
         result = caching.fetch_and_cache(patient_id) do
           patient=Vandelay::Services::Patients.new.retrieve_one(patient_id)
+          raise "Entry with ID #{patient_id} not found" unless patient
+
           api_to_use = nil
           api_to_use_id = patient.records_vendor || ""
           vendor_id = patient.vendor_id

--- a/lib/vandelay/services/patient_records.rb
+++ b/lib/vandelay/services/patient_records.rb
@@ -1,8 +1,26 @@
+require_relative '../../vandelay/util/cache'
+require 'vandelay/integrations/api1'
+require 'vandelay/integrations/api2'
+
 module Vandelay
   module Services
     class PatientRecords
-      def retrieve_record_for_patient(patient)
-        # add logic here
+      def retrieve_record_for_patient(patient_id)
+        result = {}
+
+        caching = Vandelay::Util::Cache.new
+        result = caching.fetch_and_cache(patient_id) do
+          patient=Vandelay::Services::Patients.new.retrieve_one(patient_id)
+          api_to_use = nil
+          api_to_use_id = patient.records_vendor || ""
+          vendor_id = patient.vendor_id
+
+          api_to_use = Vandelay::Integrations::Api1.new if api_to_use_id == "one"
+          api_to_use = Vandelay::Integrations::Api2.new if api_to_use_id == "two"
+
+          result = api_to_use.get_mapped_record(vendor_id) if api_to_use
+        end
+        result
       end
     end
   end

--- a/lib/vandelay/util/cache.rb
+++ b/lib/vandelay/util/cache.rb
@@ -1,9 +1,25 @@
 require 'redis'
+require 'json'
 
 module Vandelay
   module Util
     class Cache
-      # your code here
+      def initialize(redis_host: 'redis', redis_port: 6379)
+        @redis = Redis.new(host: redis_host, port: redis_port)
+      end
+
+      def fetch_and_cache(key, expiration = 600, &block)
+        cache_key = "cache:#{key}"
+        cached_result = @redis.get(cache_key)
+
+        if cached_result
+          JSON.parse(cached_result)
+        else
+          result = yield
+          @redis.set(cache_key, result.to_json, ex: expiration)
+          result
+        end
+      end
     end
   end
 end

--- a/lib/vandelay/util/cache.rb
+++ b/lib/vandelay/util/cache.rb
@@ -9,8 +9,11 @@ module Vandelay
       end
 
       def fetch_and_cache(key, expiration = 600, &block)
+        cached_result = nil
+
         cache_key = "cache:#{key}"
-        cached_result = @redis.get(cache_key)
+        # we bypass the caching for test env, it gets in the way (for this scenario)
+        cached_result = @redis.get(cache_key) unless ENV['RACK_ENV'] == 'test'
 
         if cached_result
           JSON.parse(cached_result)

--- a/spec/services/patient_records_spec.rb
+++ b/spec/services/patient_records_spec.rb
@@ -1,0 +1,93 @@
+require 'spec_helper'
+require 'vandelay/services/patient_records'
+require 'vandelay/util/cache'
+
+RSpec.describe Vandelay::Services::PatientRecords do
+  describe '#fetch_data' do
+    let(:service) { described_class.new }
+
+    context 'when API returns data and vendor api one was used'  do
+      let(:id) { 2 }
+      let(:sample_auth_data) {
+        {
+        "id": "1",
+        "token": "129e8ry23uhj23948rhu23"
+        }
+      }
+      let(:sample_record_data_api1) {
+        {
+          "id": "743",
+          "full_name": "Cosmo Kramer",
+          "dob": "1987-03-18",
+          "province": "QC",
+          "allergies": [
+            "work",
+            "conformity",
+            "paying taxes"
+          ],
+          "recent_medical_visits": 1
+        }
+      }
+
+      before do
+        # Mocking the API call
+        stub_request(:get, "http://mock_api_one/auth/1")
+          .to_return(status: 200, body: sample_auth_data.to_json, headers: { 'Content-Type': 'application/json' })
+
+        stub_request(:get, "http://mock_api_one/patients/743")
+          .to_return(status: 200, body: sample_record_data_api1.to_json, headers: { 'Content-Type': 'application/json' })
+      end
+
+      it 'fetches data from the API' do
+        data = service.retrieve_record_for_patient(id)
+        expect(data[:province]).to eq("QC")
+        expect(data[:allergies]).to eq([ "work", "conformity", "paying taxes"])
+        expect(data[:patient_id]).to eq("743")
+      end
+    end
+
+    context 'when API returns data and vendor api two was used'  do
+      let(:id) { 3 }
+      let(:sample_auth_data) {
+        {
+        "id": "1",
+        "token": "129e8ry23uhj23948rhu23"
+        }
+      }
+      let(:sample_record_data_api1) {
+        {
+          "id"=>"16",
+          "name"=>"George Costanza",
+          "birthdate"=>"1984-09-07",
+          "province_code"=>"ON",
+          "clinic_id"=>"7",
+          "allergies_list"=>["hair", "mean people", "paying the bill"],
+          "medical_visits_recently"=>17}
+      }
+
+      before do
+        # Mocking the API call
+        stub_request(:get, "http://mock_api_two/auth_tokens/1")
+          .to_return(status: 200, body: sample_auth_data.to_json, headers: { 'Content-Type': 'application/json' })
+
+        stub_request(:get, "http://mock_api_two/records/16")
+          .to_return(status: 200, body: sample_record_data_api1.to_json, headers: { 'Content-Type': 'application/json' })
+      end
+
+      it 'fetches data from the API' do
+        data = service.retrieve_record_for_patient(id)
+        expect(data[:province]).to eq("ON")
+        expect(data[:allergies]).to eq(["hair", "mean people", "paying the bill"])
+        expect(data[:patient_id]).to eq("16")
+      end
+    end
+
+    context 'when incorrect id was queried'  do
+      let(:id) { 456 }
+
+      it 'raises a error' do
+        expect {service.retrieve_record_for_patient(id)}.to raise_error("Entry with ID 456 not found")
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,8 +19,3 @@ RSpec.configure do |config|
     end
   end
 end
-
-
-
-
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,26 @@
+require 'rack/test'
+require 'rspec'
+require 'sinatra'
+require 'json'
+require 'webmock/rspec'
+
+ENV['RACK_ENV'] = 'test'
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+
+require File.expand_path '../../server.rb', __FILE__
+
+RSpec.configure do |config|
+  config.include Rack::Test::Methods
+
+  config.before(:each) do
+    def app
+      Sinatra::Application
+    end
+  end
+end
+
+
+
+
+


### PR DESCRIPTION
implemented Features: Requirements 1,2,3,4 

notes: 
Requirement 1: the endpoint url was named "patients/patient/:id" due to the name of the class itself, in real life this url would probably be something else
Requirement 2: the auth endpoint for both apis accept a token or id, this has been reduced to its simplest form due to time constraints
Requirement 3: simple caching has been added. for the purposes of this demonstration a general strategy has been used, this might be different in a production enviroment where it might be beneficial to use different caching settings for the 2 included apis
Requirement 4: a simple service spec has been added, many more tests in this context would need to be added, like for th caching class, the other services, database, etc. also, the test database has been used, might be better to be replace with factories due to dependencies (not done here for time reasons, its not super hard but would blow this out of proportions). 