### PR TITLE
ak/interview/ruby-take-home

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,9 @@ gem 'sinatra-contrib'
 gem 'puma'
 gem 'rackup'
 gem 'irb'
+gem 'httparty'
+
+group :test do
+  gem 'vcr'
+  gem 'webmock'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,34 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    bigdecimal (3.1.8)
     connection_pool (2.4.1)
+    crack (1.0.0)
+      bigdecimal
+      rexml
+    csv (3.3.0)
+    hashdiff (1.1.0)
+    httparty (0.22.0)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     io-console (0.6.0)
     irb (1.8.1)
       rdoc
       reline (>= 0.3.8)
+    mini_mime (1.1.5)
     multi_json (1.15.0)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     nio4r (2.5.9)
     pg (1.5.4)
     psych (5.1.0)
       stringio
+    public_suffix (6.0.0)
     puma (6.3.1)
       nio4r (~> 2.0)
     rack (2.2.8)
@@ -29,6 +45,8 @@ GEM
       connection_pool
     reline (0.3.8)
       io-console (~> 0.5)
+    rexml (3.3.1)
+      strscan
     ruby2_keywords (0.0.5)
     sinatra (3.1.0)
       mustermann (~> 3.0)
@@ -42,14 +60,22 @@ GEM
       sinatra (= 3.1.0)
       tilt (~> 2.0)
     stringio (3.0.8)
+    strscan (3.1.0)
     tilt (2.3.0)
+    vcr (6.2.0)
+    webmock (3.23.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
 
 PLATFORMS
   aarch64-linux
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
+  httparty
   irb
   pg (~> 1.5.3)
   puma
@@ -57,6 +83,8 @@ DEPENDENCIES
   redis
   sinatra (~> 3.1.0)
   sinatra-contrib
+  vcr
+  webmock
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/boot.rb
+++ b/boot.rb
@@ -6,5 +6,6 @@ $: << BASE_PATH + "/lib"
 require 'vandelay'
 require 'vandelay/util/db'
 require 'vandelay/models'
+require 'vandelay/integrations'
 
 Vandelay::Util::DB.verify_connection! unless Vandelay::Util::DB.connection_verified?

--- a/config.dev.yml
+++ b/config.dev.yml
@@ -6,3 +6,5 @@ integrations:
       api_base_url: mock_api_one:80
     two:
       api_base_url: mock_api_two:80
+cache:
+  redis: redis://redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
     container_name: mock_api_two
     image: clue/json-server
     volumes:
-      - ./externals/mock_api_one:/data
+      - ./externals/mock_api_two:/data
     ports:
       - "3061:80"
 

--- a/fixtures/vcr_cassettes/vendor_one.yml
+++ b/fixtures/vcr_cassettes/vendor_one.yml
@@ -1,0 +1,113 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://mock_api_one/auth/1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Powered-By:
+      - Express
+      Vary:
+      - Origin, Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '52'
+      Etag:
+      - W/"34-6T4vicdOBuaVCRtq5G6mY6IXYDk"
+      Date:
+      - Tue, 09 Jul 2024 02:31:32 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "1",
+          "token": "129e8ry23uhj23948rhu23"
+        }
+  recorded_at: Tue, 09 Jul 2024 02:31:32 GMT
+- request:
+    method: get
+    uri: http://mock_api_one/patients/?id=743
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Powered-By:
+      - Express
+      Vary:
+      - Origin, Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '220'
+      Etag:
+      - W/"dc-sBHX+DTATIMwRr1AsCTlVSjmQos"
+      Date:
+      - Tue, 09 Jul 2024 02:31:32 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        [
+          {
+            "id": "743",
+            "full_name": "Cosmo Kramer",
+            "dob": "1987-03-18",
+            "province": "QC",
+            "allergies": [
+              "work",
+              "conformity",
+              "paying taxes"
+            ],
+            "recent_medical_visits": 1
+          }
+        ]
+  recorded_at: Tue, 09 Jul 2024 02:31:32 GMT
+recorded_with: VCR 6.2.0

--- a/fixtures/vcr_cassettes/vendor_two.yml
+++ b/fixtures/vcr_cassettes/vendor_two.yml
@@ -1,0 +1,114 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://mock_api_two/auth_tokens/1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Powered-By:
+      - Express
+      Vary:
+      - Origin, Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '56'
+      Etag:
+      - W/"38-Av5sqHMfmZXa6nHzH0AnZzuw8Ao"
+      Date:
+      - Tue, 09 Jul 2024 02:41:03 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "1",
+          "auth_token": "349rijed934r8ij123$=="
+        }
+  recorded_at: Tue, 09 Jul 2024 02:41:03 GMT
+- request:
+    method: get
+    uri: http://mock_api_two/records/?id=16
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Powered-By:
+      - Express
+      Vary:
+      - Origin, Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '262'
+      Etag:
+      - W/"106-jLa1TqZpsfR7+yvQW2t83HwpM1M"
+      Date:
+      - Tue, 09 Jul 2024 02:41:03 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        [
+          {
+            "id": "16",
+            "name": "George Costanza",
+            "birthdate": "1984-09-07",
+            "province_code": "ON",
+            "clinic_id": "7",
+            "allergies_list": [
+              "hair",
+              "mean people",
+              "paying the bill"
+            ],
+            "medical_visits_recently": 17
+          }
+        ]
+  recorded_at: Tue, 09 Jul 2024 02:41:03 GMT
+recorded_with: VCR 6.2.0

--- a/lib/vandelay.rb
+++ b/lib/vandelay.rb
@@ -1,4 +1,5 @@
 require 'yaml'
+require 'redis'
 
 module Vandelay
   def self.service_name
@@ -23,5 +24,9 @@ module Vandelay
 
   def self.config_path
     @config_path ||= File.expand_path("../#{self.config_file_for_env}", File.dirname(__FILE__))
+  end
+
+  def self.cache
+    @cache ||= Redis.new(url: self.config.dig('cache', 'redis'))
   end
 end

--- a/lib/vandelay/integrations.rb
+++ b/lib/vandelay/integrations.rb
@@ -1,0 +1,1 @@
+Dir[File.dirname(__FILE__) + '/integrations/**.rb'].each {|rb| require_relative rb }

--- a/lib/vandelay/integrations/vendor_one.rb
+++ b/lib/vandelay/integrations/vendor_one.rb
@@ -1,0 +1,26 @@
+require 'httparty'
+
+module Vandelay
+  module Integrations
+    class VendorOneClient
+      include HTTParty
+
+      format :json
+      # debug_output $stdout
+
+      def initialize(config)
+        self.class.base_uri "#{config.dig('integrations', 'vendors', 'one', 'api_base_url')}"
+        self.authenticate
+      end
+
+      def authenticate
+        response = self.class.get("/auth/1").parsed_response
+        self.class.headers['Authorization'] = "Bearer #{response.dig('token')}"
+      end
+
+      def patients(id = nil)
+        self.class.get("/patients/", query: { id: id }.compact).parsed_response
+      end
+    end
+  end
+end

--- a/lib/vandelay/integrations/vendor_two.rb
+++ b/lib/vandelay/integrations/vendor_two.rb
@@ -18,7 +18,7 @@ module Vandelay
         self.class.headers['Authorization'] = "Bearer #{response.dig('auth_token')}"
       end
 
-      def records(id = nil)
+      def patients(id = nil)
         self.class.get("/records/", query: { id: id }.compact).parsed_response
       end
     end

--- a/lib/vandelay/integrations/vendor_two.rb
+++ b/lib/vandelay/integrations/vendor_two.rb
@@ -1,0 +1,26 @@
+require 'httparty'
+
+module Vandelay
+  module Integrations
+    class VendorTwoClient
+      include HTTParty
+
+      format :json
+      # debug_output $stdout
+
+      def initialize(config)
+        self.class.base_uri "#{config.dig('integrations', 'vendors', 'two', 'api_base_url')}"
+        self.authenticate
+      end
+
+      def authenticate
+        response = self.class.get("/auth_tokens/1").parsed_response
+        self.class.headers['Authorization'] = "Bearer #{response.dig('auth_token')}"
+      end
+
+      def records(id = nil)
+        self.class.get("/records/", query: { id: id }.compact).parsed_response
+      end
+    end
+  end
+end

--- a/lib/vandelay/models/base.rb
+++ b/lib/vandelay/models/base.rb
@@ -22,7 +22,7 @@ module Vandelay
         end
       end
 
-      def to_json(_opts)
+      def to_json(_opts = {})
         JSON.dump(self.to_h)
       end
 

--- a/lib/vandelay/models/patient.rb
+++ b/lib/vandelay/models/patient.rb
@@ -21,6 +21,12 @@ module Vandelay
         Vandelay::Models::Patient.new(**result)
       end
 
+      def self.find_by_id!(patient_id)
+        result = Vandelay::Models::Patient.with_id(patient_id)
+        return raise Sinatra::NotFound.new("Record Not Found!") if result.nil?
+
+        result
+      end
     end
   end
 end

--- a/lib/vandelay/rest/patients_patient.rb
+++ b/lib/vandelay/rest/patients_patient.rb
@@ -4,8 +4,17 @@ require 'vandelay/services/patient_records'
 module Vandelay
   module REST
     module PatientsPatient
+      def self.patient_records_srvc
+        @patient_records_srvc ||= Vandelay::Services::PatientRecords.new
+      end
+
       def self.registered(app)
-        # add endpoint code here
+        app.get '/patients/:id/vendor' do
+          patient = Vandelay::Models::Patient.with_id(params[:id])
+
+          results = Vandelay::REST::PatientsPatient.patient_records_srvc.retrieve_record_for_patient(patient)
+          json(results)
+        end
       end
     end
   end

--- a/lib/vandelay/rest/patients_patient.rb
+++ b/lib/vandelay/rest/patients_patient.rb
@@ -9,8 +9,13 @@ module Vandelay
       end
 
       def self.registered(app)
+        app.get '/patients/:id' do
+          patient = Vandelay::Models::Patient.find_by_id!(params[:id])
+          json(patient)
+        end
+
         app.get '/patients/:id/vendor' do
-          patient = Vandelay::Models::Patient.with_id(params[:id])
+          patient = Vandelay::Models::Patient.find_by_id!(params[:id])
 
           results = Vandelay::REST::PatientsPatient.patient_records_srvc.retrieve_record_for_patient(patient)
           json(results)

--- a/lib/vandelay/services/patient_records.rb
+++ b/lib/vandelay/services/patient_records.rb
@@ -1,8 +1,32 @@
 module Vandelay
   module Services
     class PatientRecords
+      include Vandelay::Integrations
+
       def retrieve_record_for_patient(patient)
-        # add logic here
+        result = {
+          'patient_id' => patient.id,
+          'allergies' => nil,
+          'num_medical_visits' => nil,
+          'province' => nil,
+        }
+
+        case patient.records_vendor
+        when 'one'
+          response = VendorOneClient.new(Vandelay.config).patients(patient.vendor_id)[0]
+          result.merge!(response.slice('province', 'allergies'))
+        when 'two'
+          response = VendorTwoClient.new(Vandelay.config).patients(patient.vendor_id)[0]
+          result.merge!(
+            {
+              'allergies' => response['allergies_list'],
+              'num_medical_visits' => response['medical_visits_recently'],
+              'province' => response['province_code'],
+            }
+          )
+        end
+
+        result
       end
     end
   end

--- a/lib/vandelay/services/patient_records.rb
+++ b/lib/vandelay/services/patient_records.rb
@@ -3,8 +3,9 @@ module Vandelay
     class PatientRecords
       include Vandelay::Integrations
 
-      def initialize(cache = Vandelay.cache)
+      def initialize(cache = Vandelay.cache, config = Vandelay.config)
         @cache = cache
+        @config = config
       end
 
       def retrieve_record_for_patient(patient)
@@ -27,10 +28,10 @@ module Vandelay
 
         case patient.records_vendor
         when 'one'
-          response = VendorOneClient.new(Vandelay.config).patients(patient.vendor_id)[0]
+          response = VendorOneClient.new(@config).patients(patient.vendor_id)[0]
           result.merge!(response.slice('province', 'allergies'))
         when 'two'
-          response = VendorTwoClient.new(Vandelay.config).patients(patient.vendor_id)[0]
+          response = VendorTwoClient.new(@config).patients(patient.vendor_id)[0]
           result.merge!(
             {
               'allergies' => response['allergies_list'],

--- a/lib/vandelay/services/patient_records.rb
+++ b/lib/vandelay/services/patient_records.rb
@@ -29,7 +29,13 @@ module Vandelay
         case patient.records_vendor
         when 'one'
           response = VendorOneClient.new(@config).patients(patient.vendor_id)[0]
-          result.merge!(response.slice('province', 'allergies'))
+          result.merge!(
+            {
+              'allergies' => response['allergies'],
+              'num_medical_visits' => response['recent_medical_visits'],
+              'province' => response['province']
+            }
+          )
         when 'two'
           response = VendorTwoClient.new(@config).patients(patient.vendor_id)[0]
           result.merge!(

--- a/test/all.rb
+++ b/test/all.rb
@@ -1,0 +1,11 @@
+require 'rubygems'
+require 'test/unit'
+require 'vcr'
+require_relative '../lib/vandelay'
+
+Dir[File.dirname(File.absolute_path(__FILE__)) + '/**/*_test.rb'].each {|file| require file }
+
+VCR.configure do |config|
+  config.cassette_library_dir = "fixtures/vcr_cassettes"
+  config.hook_into :webmock
+end

--- a/test/all.rb
+++ b/test/all.rb
@@ -1,5 +1,5 @@
 require 'rubygems'
-require 'test/unit'
+require 'minitest/autorun'
 require 'vcr'
 require_relative '../lib/vandelay'
 

--- a/test/lib/vandelay/integrations/vendor_one_test.rb
+++ b/test/lib/vandelay/integrations/vendor_one_test.rb
@@ -1,0 +1,22 @@
+require_relative '../../../../lib/vandelay/integrations'
+
+class VCRTest < Test::Unit::TestCase
+  include Vandelay::Integrations
+
+  def test_patients_cosmo
+    VCR.use_cassette("vendor_one") do
+      config = { 'integrations' => { 'vendors' => { 'one' => { 'api_base_url' => 'mock_api_one:80' }}}}
+
+      cosmo = VendorOneClient.new(config).patients(743)[0]
+      expectation = {
+        "allergies" => ["work", "conformity", "paying taxes"],
+        "dob" => "1987-03-18",
+        "full_name" => "Cosmo Kramer",
+        "id" => "743",
+        "province" => "QC",
+        "recent_medical_visits" => 1
+      }
+      assert_equal expectation, cosmo
+    end
+  end
+end

--- a/test/lib/vandelay/integrations/vendor_one_test.rb
+++ b/test/lib/vandelay/integrations/vendor_one_test.rb
@@ -1,6 +1,6 @@
 require_relative '../../../../lib/vandelay/integrations'
 
-class VCRTest < Test::Unit::TestCase
+class VendorOneTest < Minitest::Test
   include Vandelay::Integrations
 
   def test_patients_cosmo

--- a/test/lib/vandelay/integrations/vendor_two_test.rb
+++ b/test/lib/vandelay/integrations/vendor_two_test.rb
@@ -1,0 +1,23 @@
+require_relative '../../../../lib/vandelay/integrations'
+
+class VCRTest < Test::Unit::TestCase
+  include Vandelay::Integrations
+
+  def test_records_george
+    VCR.use_cassette("vendor_two") do
+      config = { 'integrations' => { 'vendors' => { 'two' => { 'api_base_url' => 'mock_api_two:80' }}}}
+
+      george = VendorTwoClient.new(config).records(16)[0]
+      expectation = {
+        "allergies_list" => ["hair", "mean people", "paying the bill"],
+        "birthdate" => "1984-09-07",
+        "clinic_id" => "7",
+        "id" => "16",
+        "medical_visits_recently" => 17,
+        "name" => "George Costanza",
+        "province_code" => "ON"
+      }
+      assert_equal expectation, george
+    end
+  end
+end

--- a/test/lib/vandelay/integrations/vendor_two_test.rb
+++ b/test/lib/vandelay/integrations/vendor_two_test.rb
@@ -3,11 +3,11 @@ require_relative '../../../../lib/vandelay/integrations'
 class VCRTest < Test::Unit::TestCase
   include Vandelay::Integrations
 
-  def test_records_george
+  def test_patients_george
     VCR.use_cassette("vendor_two") do
       config = { 'integrations' => { 'vendors' => { 'two' => { 'api_base_url' => 'mock_api_two:80' }}}}
 
-      george = VendorTwoClient.new(config).records(16)[0]
+      george = VendorTwoClient.new(config).patients(16)[0]
       expectation = {
         "allergies_list" => ["hair", "mean people", "paying the bill"],
         "birthdate" => "1984-09-07",

--- a/test/lib/vandelay/integrations/vendor_two_test.rb
+++ b/test/lib/vandelay/integrations/vendor_two_test.rb
@@ -1,6 +1,6 @@
 require_relative '../../../../lib/vandelay/integrations'
 
-class VCRTest < Test::Unit::TestCase
+class VendorTwoTest < Minitest::Test
   include Vandelay::Integrations
 
   def test_patients_george

--- a/test/lib/vandelay/services/patient_records_integration_test.rb
+++ b/test/lib/vandelay/services/patient_records_integration_test.rb
@@ -36,7 +36,7 @@ class PatientRecordsIntegrationTest < Minitest::Test
         {
           'patient_id' => 2,
           'allergies' => ["work", "conformity", "paying taxes"],
-          'num_medical_visits' => nil,
+          'num_medical_visits' => 1,
           'province' => "QC",
         }
       assert_equal expectation, PatientRecords.new.consolidate_from_services(patient)

--- a/test/lib/vandelay/services/patient_records_integration_test.rb
+++ b/test/lib/vandelay/services/patient_records_integration_test.rb
@@ -1,0 +1,63 @@
+require_relative '../../../../lib/vandelay/integrations'
+require_relative '../../../../lib/vandelay/services/patient_records'
+
+class PatientRecordsIntegrationTest < Minitest::Test
+  include Vandelay::Services
+
+  def test_vendor_two_consolidation
+    VCR.use_cassette("vendor_two") do
+      patient = OpenStruct.new(
+        {
+          id: 3,
+          records_vendor: 'two',
+          vendor_id: 16
+        }
+      )
+      expectation = {
+        'patient_id' => 3,
+        'allergies' => ["hair", "mean people", "paying the bill"],
+        'num_medical_visits' => 17,
+        'province' => "ON"
+      }
+      assert_equal expectation, PatientRecords.new.consolidate_from_services(patient)
+    end
+  end
+
+  def test_vendor_one_consolidation
+    VCR.use_cassette("vendor_one") do
+      patient = OpenStruct.new(
+        {
+          id: 2,
+          records_vendor: 'one',
+          vendor_id: 743
+        }
+      )
+      expectation =
+        {
+          'patient_id' => 2,
+          'allergies' => ["work", "conformity", "paying taxes"],
+          'num_medical_visits' => nil,
+          'province' => "QC",
+        }
+      assert_equal expectation, PatientRecords.new.consolidate_from_services(patient)
+    end
+  end
+
+  def test_no_vendor_consolidation
+    patient = OpenStruct.new(
+      {
+        id: 1,
+        records_vendor: nil,
+        vendor_id: nil
+      }
+    )
+    expectation =
+      {
+        'patient_id' => 1,
+        'allergies' => nil,
+        'num_medical_visits' => nil,
+        'province' => nil,
+      }
+    assert_equal expectation, PatientRecords.new.consolidate_from_services(patient)
+  end
+end

--- a/test/lib/vandelay/services/patient_records_test.rb
+++ b/test/lib/vandelay/services/patient_records_test.rb
@@ -1,0 +1,63 @@
+require_relative '../../../../lib/vandelay/integrations'
+require_relative '../../../../lib/vandelay/services/patient_records'
+
+class PatientRecords < Test::Unit::TestCase
+  include Vandelay::Services
+
+  def test_vendor_two_extension
+    VCR.use_cassette("vendor_two") do
+      patient = OpenStruct.new(
+        {
+          id: 3,
+          records_vendor: 'two',
+          vendor_id: 16
+        }
+      )
+      expectation = {
+        'patient_id' => 3,
+        'allergies' => ["hair", "mean people", "paying the bill"],
+        'num_medical_visits' => 17,
+        'province' => "ON"
+      }
+      assert_equal expectation, PatientRecords.new.retrieve_record_for_patient(patient)
+    end
+  end
+
+  def test_vendor_one_extension
+    VCR.use_cassette("vendor_one") do
+      patient = OpenStruct.new(
+        {
+          id: 2,
+          records_vendor: 'one',
+          vendor_id: 743
+        }
+      )
+      expectation =
+        {
+          'patient_id' => 2,
+          'allergies' => ["work", "conformity", "paying taxes"],
+          'num_medical_visits' => nil,
+          'province' => "QC",
+        }
+      assert_equal expectation, PatientRecords.new.retrieve_record_for_patient(patient)
+    end
+  end
+
+  def test_no_vendor
+    patient = OpenStruct.new(
+      {
+        id: 1,
+        records_vendor: nil,
+        vendor_id: nil
+      }
+    )
+    expectation =
+      {
+        'patient_id' => 1,
+        'allergies' => nil,
+        'num_medical_visits' => nil,
+        'province' => nil,
+      }
+    assert_equal expectation, PatientRecords.new.retrieve_record_for_patient(patient)
+  end
+end


### PR DESCRIPTION
## Contributions

- A `patients/:id` endpoint was added to retrieve a single patient record from the database
- A `patients/:id/vendor` endpoint was added to retrieve extended patient data from external services
- The patient model was extended to support `find_by_id!` which throws a 404 when a record is not found
- Vendor services were added (tests included). Services make use of the [HTTParty gem](https://github.com/jnunemaker/httparty). Service tests made use of the [VCR gem](https://github.com/vcr/vcr) so the actual endpoints never need to be called again. [Minitest](https://github.com/minitest/minitest) was used as a general framework since it allows for unit testing and mocks.
- Caching was included for the the Vendor services lookup (the [cache testing](https://github.com/AkiraMD/ruby-senior-take-home-assignment/compare/main...AdamDotCom:ruby-senior-take-home-assignment:ak/interview/ruby-take-home?expand=1#diff-780fc77d8e8efe577ef189be56b261acda312c716016877c83edf4e8c7ff53dcR18) made use of mocks)

## ToDo
- Consider putting Authentication and Authorization on the entire API. Presently anyone can access anyone's medical records.
- Consider backfilling the existing API endpoints with tests.
- Consider backfilling the existing Model objects with tests.
- Consider putting required parameter validation on endpoints and return exceptions if requirements aren't met.
- Reconsider the authentication scheme in the Vendor services. How long would are tokens valid in the real world?
- Consider moving the Vendor services into a Factory. How many more of these services will we have in the future?

## Endpoint Results
### patients/:id
```
curl -s http://localhost:3087/patients/1 | json_pp
{
   "date_of_birth" : "1988-10-12",
   "full_name" : "Elaine Benes",
   "id" : "1",
   "records_vendor" : null,
   "vendor_id" : null
}
```
```
curl -s http://localhost:3087/patients/2 | json_pp      
{
   "date_of_birth" : "1987-03-18",
   "full_name" : "Cosmo Kramer",
   "id" : "2",
   "records_vendor" : "one",
   "vendor_id" : "743"
}
```
```
curl -s http://localhost:3087/patients/3 | json_pp
{
   "date_of_birth" : "1984-09-07",
   "full_name" : "George Costanza",
   "id" : "3",
   "records_vendor" : "two",
   "vendor_id" : "16"
}
```
```
curl -I http://localhost:3087/patients/100
HTTP/1.1 404 Not Found
```

### patients/:id/vendor
```
curl -s http://localhost:3087/patients/1/vendor | json_pp
{
   "allergies" : null,
   "num_medical_visits" : null,
   "patient_id" : "1",
   "province" : null
}
```
```
curl -s http://localhost:3087/patients/2/vendor | json_pp
{
   "allergies" : [
      "work",
      "conformity",
      "paying taxes"
   ],
   "num_medical_visits" : 1,
   "patient_id" : "2",
   "province" : "QC"
}
```
```
curl -s http://localhost:3087/patients/3/vendor | json_pp
{
   "allergies" : [
      "hair",
      "mean people",
      "paying the bill"
   ],
   "num_medical_visits" : 17,
   "patient_id" : "3",
   "province" : "ON"
}
```
```
curl -I http://localhost:3087/patients/100/vendor       
HTTP/1.1 404 Not Found
```

## Tests

Tests can be run by `ruby test/all.rb`

```
# ruby test/all.rb
Run options: --seed 57918

# Running:

.......

Finished in 0.048875s, 143.2237 runs/s, 102.3026 assertions/s.

7 runs, 5 assertions, 0 failures, 0 errors, 0 skips
```