### PR TITLE
Implement API endpoints to fetch patient information and Vendor Integrations to fetch patient records

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,11 @@ gem 'sinatra-contrib'
 gem 'puma'
 gem 'rackup'
 gem 'irb'
+# Define a group :test so that gems are installed only for testing
+# These gems will not be installed in production environments
+group :test do
+  gem 'rack-test'
+  gem 'mock_redis'
+  gem 'rspec'
+  gem 'webmock'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,20 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    bigdecimal (3.1.8)
     connection_pool (2.4.1)
+    crack (1.0.0)
+      bigdecimal
+      rexml
+    diff-lcs (1.5.1)
+    hashdiff (1.1.1)
     io-console (0.6.0)
     irb (1.8.1)
       rdoc
       reline (>= 0.3.8)
+    mock_redis (0.44.0)
     multi_json (1.15.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
@@ -13,11 +22,14 @@ GEM
     pg (1.5.4)
     psych (5.1.0)
       stringio
+    public_suffix (6.0.1)
     puma (6.3.1)
       nio4r (~> 2.0)
     rack (2.2.8)
     rack-protection (3.1.0)
       rack (~> 2.2, >= 2.2.4)
+    rack-test (2.1.0)
+      rack (>= 1.3)
     rackup (1.0.0)
       rack (< 3)
       webrick
@@ -29,6 +41,21 @@ GEM
       connection_pool
     reline (0.3.8)
       io-console (~> 0.5)
+    rexml (3.3.5)
+      strscan
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
     ruby2_keywords (0.0.5)
     sinatra (3.1.0)
       mustermann (~> 3.0)
@@ -42,7 +69,12 @@ GEM
       sinatra (= 3.1.0)
       tilt (~> 2.0)
     stringio (3.0.8)
+    strscan (3.1.0)
     tilt (2.3.0)
+    webmock (3.23.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
 
 PLATFORMS
@@ -51,12 +83,16 @@ PLATFORMS
 
 DEPENDENCIES
   irb
+  mock_redis
   pg (~> 1.5.3)
   puma
+  rack-test
   rackup
   redis
+  rspec
   sinatra (~> 3.1.0)
   sinatra-contrib
+  webmock
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - ./postgres-data:/var/lib/postgresql/data
       - ./db/schema_snapshots/init.sql:/docker-entrypoint-initdb.d/init.sql
     ports:
-      - '5439:5432'
+      - "5439:5432"
     environment:
       POSTGRES_USER: vandelay_app
       POSTGRES_PASSWORD: secret
@@ -27,7 +27,7 @@ services:
       - ./postgres-data-test:/var/lib/postgresql/data
       - ./db/schema_snapshots/init.sql:/docker-entrypoint-initdb.d/init.sql
     ports:
-      - '5440:5432'
+      - "5440:5432"
     environment:
       POSTGRES_USER: vandelay_app
       POSTGRES_PASSWORD: secret
@@ -45,7 +45,7 @@ services:
     container_name: redis
     image: redis:latest
     ports:
-      - '6387:6379'
+      - "6387:6379"
     restart: unless-stopped
 
   mock_api_one:
@@ -60,20 +60,19 @@ services:
     container_name: mock_api_two
     image: clue/json-server
     volumes:
-      - ./externals/mock_api_one:/data
+      - ./externals/mock_api_two:/data
     ports:
       - "3061:80"
-
   rest_server:
     build: .
     container_name: rest_server
     volumes:
       - .:/app
     ports:
-      - '3087:3087'
+      - "3087:3087"
     working_dir: /app
-    entrypoint:
-      - ./entry.sh
+    # This change is to allow test parameter to be passed when running through docker-compose to run tests
+    command: ./entry.sh
     depends_on:
       postgres:
         condition: service_started

--- a/entry.sh
+++ b/entry.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
 
-APP_ENV=dev bundle exec rackup --host 0.0.0.0 -p 3087
+# If test parameter is passed, all Rspec tests will be executed
+#
+if [ "$1" = "test" ]; then
+  APP_ENV=test bundle exec rspec
+else
+  APP_ENV=dev bundle exec rackup --host 0.0.0.0 -p 3087
+fi

--- a/lib/vandelay/integrations/base.rb
+++ b/lib/vandelay/integrations/base.rb
@@ -1,0 +1,78 @@
+require 'net/http'
+require 'json'
+
+module Vandelay
+  module Integrations
+    class Base
+      def initialize
+        @base_url = Vandelay.config.dig('integrations', 'vendors', vendor_name, 'api_base_url')
+      end
+
+      # Method should be implemented in subclass
+      # @param [Integer] patient_id
+      #
+      def fetch_patient_record(patient_id)
+        raise NotImplementedError
+      end
+
+      private
+
+      # Method should be implemented in subclass
+      #
+      def vendor_name
+        raise NotImplementedError
+      end
+
+      # Fetches authorization token from authentication endpoint and parses response body
+      # auth_endpoint is defined as an abstract method at the bottom of this class
+      # It should be implemented by subclasses to provide the specific authentication endpoint
+      # Response for get request varies for the two vendors, token is returned as 'auth_token'
+      # for vendor_two and as 'token' for vendor_one
+      #
+      def get_auth_token
+        response = make_request(:get, auth_endpoint)
+        JSON.parse(response.body)['auth_token'] || JSON.parse(response.body)['token']
+      end
+
+      # Makes request to the api endpoint to fetch patient records information. This method
+      # makes a call to get authorization token when the endpoint is not auth_endpoint. It
+      # adds Auth token as a bearer token to Authorization header, and then makes a call
+      # to the actual API endpoint to fetch data
+      # 1. subclass calls makes_request with actual endpoint to fetch patient records information
+      # 2. make_request checks if the endpoint is not auth_endpoint
+      # 3. If it is not auth_endpoint, it calls get_auth_token
+      # 4. get_auth_token makes request with auth_endpoint
+      # 5. An infinite loop is avoided by using conditional check of endpoint == auth_endpoint
+      # 6. The auth request is made without Authorization header
+      # 7. The token is returned and used for original request
+      # @param [Symbol] method
+      # @param [String] endpoint
+      # @param [Hash] headers
+      # @return [Net::HTTP::Response]
+      #
+      def make_request(method, endpoint, headers = {})
+        uri = URI("http://#{@base_url}#{endpoint}")
+        http = Net::HTTP.new(uri.host, uri.port)
+        
+        request = case method
+                  when :get
+                    Net::HTTP::Get.new(uri)
+                  else
+                    raise "Unsupported HTTP method: #{method}"
+                  end
+
+        headers.each { |key, value| request[key] = value }
+
+        request['Authorization'] = "Bearer #{get_auth_token}" unless endpoint == auth_endpoint
+
+        http.request(request)
+      end
+
+      # Implemented in the subclass
+      #
+      def auth_endpoint
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/lib/vandelay/integrations/vendor_one.rb
+++ b/lib/vandelay/integrations/vendor_one.rb
@@ -1,0 +1,42 @@
+module Vandelay
+  module Integrations
+    # Ensure the Base class is required
+    #
+    require_relative 'base'
+
+    class VendorOne < Base
+
+      # Fetches patient record information
+      # @param [Integer] patient_id
+      # @return [Hash]
+      #
+      def fetch_patient_record(patient_id)
+        response = make_request(:get, "/patients/#{patient_id}")
+        data = JSON.parse(response.body)
+
+        {
+          province: data['province'],
+          allergies: data['allergies'],
+          num_medical_visits: data['recent_medical_visits']
+        }
+      end
+
+      private
+
+      # Name of vendor
+      # @return [String]
+      #
+      def vendor_name
+        'one'
+      end
+      
+      # auth_endpoint is defined in the subclass, since it varies depending upon
+      # the vendor
+      # @return [String]
+      #
+      def auth_endpoint
+        '/auth/1'
+      end
+    end
+  end
+end

--- a/lib/vandelay/integrations/vendor_two.rb
+++ b/lib/vandelay/integrations/vendor_two.rb
@@ -1,0 +1,41 @@
+module Vandelay
+  module Integrations
+    # Ensure the Base class is required
+    require_relative 'base'
+
+    class VendorTwo < Base
+      
+      # Fetches patient record information
+      # @param [Integer] patient_id
+      # @return [Hash]
+      #
+      def fetch_patient_record(patient_id)
+        response = make_request(:get, "/records/#{patient_id}")
+        data = JSON.parse(response.body)
+
+        {
+          province: data['province_code'],
+          allergies: data['allergies_list'],
+          num_medical_visits: data['medical_visits_recently']
+        }
+      end
+
+      private
+
+      # Name of vendor
+      # @return [String]
+      #
+      def vendor_name
+        'two'
+      end
+
+      # auth_endpoint is defined in the subclass, since it varies depending upon
+      # the vendor
+      # @return [String]
+      #
+      def auth_endpoint
+        '/auth_tokens/1'
+      end
+    end
+  end
+end

--- a/lib/vandelay/rest/patients_patient.rb
+++ b/lib/vandelay/rest/patients_patient.rb
@@ -1,11 +1,62 @@
 require 'vandelay/services/patients'
 require 'vandelay/services/patient_records'
+require 'sinatra/base'
+require 'sinatra/json'
 
 module Vandelay
   module REST
     module PatientsPatient
+      # Initializes Patients class
+      #
+      def self.patients_srvc
+        @patients_srvc ||= Vandelay::Services::Patients.new
+      end
+
+      # Initializes PatientRecords class
+      #
+      def self.patient_records_srvc
+        @patient_records_srvc ||= Vandelay::Services::PatientRecords
+      end
+
+      # Defines the route and registers the route with application for fetching
+      # patient record information
+      # Patients Class in Services is initialized if instance does not exist and
+      # used to fetch patient information from db
+      # If patient record exists in database, PatientsPatient instance is used to
+      # fetch patient record information through integration with external vendor
+      # 
       def self.registered(app)
-        # add endpoint code here
+        app.helpers Sinatra::JSON
+
+        app.get '/patients/:patient_id' do
+          patient_id = params['patient_id'].to_i
+          patient = Vandelay::REST::PatientsPatient.patients_srvc.retrieve_one(patient_id)
+      
+          if patient
+            json patient.attributes.to_hash
+          else
+            status 404
+            json({ error: 'Patient not found' })
+          end
+        end
+
+        app.get '/patients/:patient_id/record' do
+          patient_id = params['patient_id'].to_i
+          patient = Vandelay::REST::PatientsPatient.patients_srvc.retrieve_one(patient_id)
+
+          if patient
+            records = Vandelay::REST::PatientsPatient.patient_records_srvc.fetch(patient)
+            json({
+              patient_id: patient.id,
+              province: records[:province],
+              allergies: records[:allergies],
+              num_medical_visits: records[:num_medical_visits]
+            })
+          else
+            status 404
+            json({ error: 'Patient not found' })
+          end
+        end
       end
     end
   end

--- a/lib/vandelay/services/patient_records.rb
+++ b/lib/vandelay/services/patient_records.rb
@@ -1,8 +1,59 @@
+require 'vandelay/util/cache'
+require 'vandelay/integrations/vendor_one'
+require 'vandelay/integrations/vendor_two'
+
 module Vandelay
   module Services
     class PatientRecords
+      def initialize
+        @cache = Vandelay::Util::Cache.new
+      end
+
+      # Fetches patient record information
+      # @param [Patient] patient
+      # @return [Hash]
+      #
+      def self.fetch(patient)
+        new.retrieve_record_for_patient(patient)
+      end
+
+      # Retrieves record for patient from cache or by making an API call to
+      # external vendor
+      # @param [Patient] patient
+      # @return [Hash]
+      #
       def retrieve_record_for_patient(patient)
-        # add logic here
+        return {} unless patient.records_vendor && patient.vendor_id
+
+        cache_key = "patient_record:#{patient.id}:#{patient.records_vendor}:#{patient.vendor_id}"
+        
+        @cache.fetch(cache_key, expires_in: 600) do
+          integration = get_integration(patient.records_vendor)
+          records = integration.fetch_patient_record(patient.vendor_id)
+
+          {
+            province: records[:province],
+            allergies: records[:allergies],
+            num_medical_visits: records[:num_medical_visits]
+          }
+        end
+      end
+
+      private
+
+      # Get integration class for specific vendor defined as a subclass
+      # @param [String] vendor
+      # @return [Vandelay::Integrations::VendorOne | Vandelay::Integrations::VendorTwo]
+      #
+      def get_integration(vendor)
+        case vendor
+        when 'one'
+          Vandelay::Integrations::VendorOne.new
+        when 'two'
+          Vandelay::Integrations::VendorTwo.new
+        else
+          raise "Unknown vendor: #{vendor}"
+        end
       end
     end
   end

--- a/lib/vandelay/util/cache.rb
+++ b/lib/vandelay/util/cache.rb
@@ -3,7 +3,30 @@ require 'redis'
 module Vandelay
   module Util
     class Cache
-      # your code here
+      # Initializes this class with a redis instance
+      #
+      def initialize
+        @redis = Redis.new(url: "redis://redis:6379/0")
+      end
+
+      # Fetches value of given key in Redis if present
+      # Sets key, value pair with an expirty of 10 minutes
+      # if not present
+      # @param [String] key
+      # @param [Integer]
+      # @return [JSON]
+      #
+      def fetch(key, expires_in: 600)
+        value = @redis.get(key)
+        return JSON.parse(value, symbolize_names: true) if value
+
+        # if key is not present, block passed to this method is used to fetch information
+        # and persisted in Redis with expiry of 10 minutes
+        #
+        value = yield
+        @redis.setex(key, expires_in, value.to_json)
+        value
+      end
     end
   end
 end

--- a/spec/integration/patients_patient_spec.rb
+++ b/spec/integration/patients_patient_spec.rb
@@ -1,0 +1,108 @@
+require 'spec_helper'
+require 'rack/test'
+require 'sinatra/base'
+require 'sinatra/json'
+require 'vandelay/rest/patients_patient'
+
+RSpec.describe Vandelay::REST::PatientsPatient do
+  include Rack::Test::Methods
+
+  let(:app) do
+    Class.new(Sinatra::Base) do
+      helpers Sinatra::JSON
+      register Vandelay::REST::PatientsPatient
+    end
+  end
+
+  describe "GET /patients/:id" do
+    context "when the patient exists" do
+      let(:patient_id) { 789 }
+      let(:patient_info) do
+        {
+          id: patient_id,
+          name: 'John Doe',
+          age: 35,
+          gender: 'Male'
+        }
+      end
+     let(:patient_record) { double('Patient', attributes: patient_info) }
+  
+      before do
+        allow(Vandelay::REST::PatientsPatient.patients_srvc).to receive(:retrieve_one).with(patient_id).and_return(patient_record)
+      end
+  
+      it "returns patient information with status 200" do
+        get "/patients/#{patient_id}"
+  
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)).to eq({
+          "id" => patient_id,
+          "name" => "John Doe",
+          "age" => 35,
+          "gender" => "Male"
+        })
+      end
+    end
+	
+    context "when the patient does not exist" do
+      let(:patient_id) { 999 }
+  
+      before do
+        allow(Vandelay::REST::PatientsPatient.patients_srvc).to receive(:retrieve_one).with(patient_id).and_return(nil)
+      end
+  
+      it "returns a 404 error" do
+        get "/patients/#{patient_id}"
+  
+        expect(last_response.status).to eq(404)
+        expect(JSON.parse(last_response.body)).to eq({ "error" => "Patient not found" })
+      end
+    end
+  end
+
+  describe "GET /patients/:patient_id/record" do
+    context "when the patient exists" do
+      let(:patient_id) { 123 }
+      let(:patient) { double('Patient', id: patient_id) }
+      let(:patient_records) do
+        {
+          province: 'Ontario',
+          allergies: ['Peanuts', 'Penicillin'],
+          num_medical_visits: 5
+        }
+      end
+
+      before do
+        allow(Vandelay::REST::PatientsPatient.patients_srvc).to receive(:retrieve_one).with(patient_id).and_return(patient)
+        allow(Vandelay::REST::PatientsPatient.patient_records_srvc).to receive(:fetch).with(patient).and_return(patient_records)
+      end
+
+      it "returns patient information with status 200" do
+        get "/patients/#{patient_id}/record"
+
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)).to eq({
+          "patient_id" => patient_id,
+          "province" => "Ontario",
+          "allergies" => ["Peanuts", "Penicillin"],
+          "num_medical_visits" => 5
+        })
+      end
+    end
+
+    context "when the patient does not exist" do
+      let(:patient_id) { 456 }
+
+      before do
+        allow(Vandelay::REST::PatientsPatient.patients_srvc).to receive(:retrieve_one).with(patient_id).and_return(nil)
+      end
+
+      it "returns a 404 error" do
+        get "/patients/#{patient_id}/record"
+
+        expect(last_response.status).to eq(404)
+        expect(JSON.parse(last_response.body)).to eq({ "error" => "Patient not found" })
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+ENV['RACK_ENV'] = 'test'
+
+require_relative '../boot'
+require 'rspec'
+require 'rack/test'
+require 'webmock/rspec'
+require 'mock_redis'
+
+RSpec.configure do |config|
+  config.include Rack::Test::Methods
+  config.before(:each) do
+   redis = MockRedis.new
+   redis.flushdb
+  end
+end
+
+def app
+  Sinatra::Application
+end

--- a/spec/vandelay/services/patient_records_spec.rb
+++ b/spec/vandelay/services/patient_records_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+require 'vandelay/services/patient_records'
+require 'vandelay/integrations/vendor_one'
+require 'vandelay/integrations/vendor_two'
+
+RSpec.describe Vandelay::Services::PatientRecords do
+  let(:cache) { instance_double(Vandelay::Util::Cache) }
+
+  before do
+    allow(Vandelay::Util::Cache).to receive(:new).and_return(cache)
+  end
+
+  shared_examples 'patient record retrieval' do |vendor, vendor_class|
+    let(:patient) { double('Patient', records_vendor: vendor, vendor_id: '123', id: 12) }
+    let(:integration) { instance_double(vendor_class) }
+
+    before do
+      allow(vendor_class).to receive(:new).and_return(integration)
+    end
+
+    it 'fetches patient record from cache if available' do
+      cached_record = { province: 'ON', allergies: ['peanuts'], num_medical_visits: 5 }
+      allow(cache).to receive(:fetch).and_return(cached_record)
+
+      result = described_class.fetch(patient)
+      expect(result).to eq(cached_record)
+    end
+
+    it 'fetches patient record from integration if not in cache' do
+      integration_record = { province: 'QC', allergies: ['cats'], num_medical_visits: 3 }
+      allow(cache).to receive(:fetch).and_yield
+      allow(integration).to receive(:fetch_patient_record).and_return(integration_record)
+
+      result = described_class.fetch(patient)
+      expect(result).to eq(integration_record)
+    end
+  end
+
+  describe 'with VendorOne' do
+    include_examples 'patient record retrieval', 'one', Vandelay::Integrations::VendorOne
+  end
+
+  describe 'with VendorTwo' do
+    include_examples 'patient record retrieval', 'two', Vandelay::Integrations::VendorTwo
+  end
+end


### PR DESCRIPTION
1. Include a new group in Gemfile which can install gems needed to run tests: I have used RSpec test framework to include unit tests for services and integration test. Integration test runs for both newly added API endpoints - to fetch individual patient information, and to fetch records for patient by integrating with external vendors API
2. Problems encountered: 
   a. docker-compose.yml included an incorrect mapping for mock_api_two volume, it mapped both mock_api_one and mock_api_two to mock_api_one:/data which was causing /auth_tokens/1 request to fail. This is because only the db.json file from mock_api_one was getting loaded and /auth/1 endpoint was available. I have updated docker-compose.yml file to change the volume mapping for 'mount_api_two'. 
  b. entrypoint defined for rest-server did not allow any command line arguments to be passed as parameters when running tests. If I updated it to include test, it would always run in test mode. I have updated the docker-compose.yml file to replace entrypoint by command which can take arguments if provided
 c. entry.sh: This only ran the docker containers in development mode. I have updated it to check for test parameter, so it can execute tests and not start development server
3. To run tests: `docker-compose run rest_server ./entry.sh test`
4. Server can be started in development mode using `docker-compose up` and following commands can be used to test the implementation:
    `a. curl http://localhost:3087/patients/1`
    `b. curl http://localhost:3087/patients/1/record`
    `c. curl http://localhost:3087/patients/2`
    `d. curl curl http://localhost:3087/patients/2/record`
    `e. curl http://localhost:3087/patients/3`
    `f. curl http://localhost:3087/patients/3/record`
    `g. curl http://localhost:3087/patients/4`
    `h. curl http://localhost:3087/patients/4/record`
